### PR TITLE
Remove shallow settings from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,12 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	shallow = false
 [submodule "lib/murky"]
 	path = lib/murky
 	url = https://github.com/dmfxyz/murky
-	shallow = true
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	shallow = true
 [submodule "lib/solidity-bytes-utils"]
 	path = lib/solidity-bytes-utils
 	url = https://github.com/GNSPS/solidity-bytes-utils
-	shallow = true


### PR DESCRIPTION
I added the `shallow` settings to `.gitmodules` in an effort to reduce the amount of data downloaded by `forge init -t risc0/bonsai-foundry-template`. It turns out not to really work, and partially breaks `forge init`. This PR removes those settings.
