### PR TITLE
Initialize CI with copy of rules from risc0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+---
+
+## Bug Report
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Your Environment
+
+- risc0-ethereum version:
+- Rust version:
+- Platform/OS:
+
+## Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Submit a new feature request
+title: "[Feature]"
+labels: enhancement
+---
+
+## Feature
+<!-- A clear and concise description of what you want to happen. -->
+
+## Motivation
+<!-- Why should this feature be implemented? -->
+
+## Implementation
+<!-- What needs to be built for the feature to be supported? -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+        with:
+          version: nightly-09fe3e041369a816365a020f715ad6f94dbce9f2
       - run: cargo fmt --all --check
       - run: cargo fmt --all --check --manifest-path relay/tests/methods/guest/Cargo.toml
       - run: cargo clippy
@@ -65,6 +68,8 @@ jobs:
           RISC0_SKIP_BUILD: true
       - run: cargo sort --workspace --check
       - run: cargo sort --workspace --check relay/tests/methods/guest
+      - run: forge fmt --check
+        working-directory: contracts
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -101,6 +106,9 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       # TODO(victor) How to install cargo-risczero
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
+      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+        with:
+          version: nightly-09fe3e041369a816365a020f715ad6f94dbce9f2
       - name: build workspace
         run: |
           cargo test -F $FEATURE --workspace --timings --no-run \
@@ -120,6 +128,8 @@ jobs:
           name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}
           path: target/cargo-timings/
           retention-days: 5
+      - run: forge test -vvv
+        working-directory: contracts
       - run: sccache --show-stats
 
   doc:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,141 @@
+name: CI
+
+on:
+  merge_group:
+  pull_request:
+    branches: [main, "release-*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# this is needed to gain access via OIDC to the S3 bucket for caching
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RISC0_TOOLCHAIN_VERSION: v2024-01-31.1
+
+jobs:
+  # see: https://github.com/orgs/community/discussions/26822
+  main-status-check:
+    if: always()
+    needs:
+      - check
+      - check-benchmarks
+      - check-template
+      - crates-validator
+      - doc
+      - examples
+      - reproducible-build
+      - stark2snark
+      - test
+      - web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all job status
+        # see https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is required by license-check.py
+          fetch-depth: 0
+      - uses: ./.github/actions/rustup
+      - name: Install cargo-sort
+        uses: risc0/cargo-install@b9307573043522ab0d3e3be64a51763b765b52a4
+        with:
+          crate: cargo-sort
+          version: "1.0"
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: cargo fmt --all --check
+      - run: cargo fmt --all --check --manifest-path relay/tests/methods/guest/Cargo.toml
+      - run: cargo clippy
+        env:
+          RISC0_SKIP_BUILD: true
+      - run: cargo sort --workspace --check
+      - run: cargo sort --workspace --check relay/tests/methods/guest
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: python license-check.py
+
+  test:
+    runs-on: [self-hosted, prod, "${{ matrix.os }}", "${{ matrix.device }}"]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [Linux, macOS]
+        feature: [default]
+        device: [cpu]
+        include:
+          - os: Linux
+            feature: default
+            device: nvidia_rtx_a5000
+          - os: macOS
+            feature: default
+            device: apple_m2_pro
+    env:
+      FEATURE: ${{ matrix.feature }}
+      RISC0_BUILD_LOCKED: 1
+      RUST_BACKTRACE: full
+    steps:
+      # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
+      - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
+      - uses: actions/checkout@v4
+      - if: matrix.feature == 'cuda'
+        uses: ./.github/actions/cuda
+      - uses: ./.github/actions/rustup
+      - uses: ./.github/actions/sccache
+        with:
+          key: ${{ matrix.os }}-${{ matrix.feature }}
+      # TODO(victor) How to install cargo-risczero
+      - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
+      - name: build workspace
+        run: |
+          cargo test -F $FEATURE --workspace --timings --no-run \
+            --exclude doc-test \
+            --exclude bonsai-ethereum-contracts \
+            --exclude bonsai-ethereum-relay \
+            --exclude bonsai-rest-api-mock
+      - name: test workspace
+        run: |
+          cargo test -F $FEATURE -F prove --workspace --timings \
+            --exclude doc-test \
+            --exclude bonsai-ethereum-contracts \
+            --exclude bonsai-ethereum-relay \
+            --exclude bonsai-rest-api-mock
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}
+          path: target/cargo-timings/
+          retention-days: 5
+      - run: sccache --show-stats
+
+  doc:
+    runs-on: [self-hosted, prod, macOS, cpu]
+    steps:
+      # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
+      - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rustup
+      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+        with:
+          version: nightly-09fe3e041369a816365a020f715ad6f94dbce9f2
+      - uses: ./.github/actions/sccache
+        with:
+          key: macOS-default
+      # TODO(victor): Figure out how to install cargo-risczro here
+      - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
+      - run: cargo doc --no-deps --exclude=risc0-ethereum-relay-test-methods --workspace
+      - run: sccache --show-stats

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -9,9 +9,9 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+hex = "0.4" 
 risc0-build = { workspace = true }
 risc0-zkp = { workspace = true }
-hex = "0.4" 
 
 [features]
 default = []

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RISC Zero, Inc.
+// Copyright 2024 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contracts/src/RiscZeroCheats.sol
+++ b/contracts/src/RiscZeroCheats.sol
@@ -75,5 +75,4 @@ abstract contract RiscZeroCheats is CommonBase {
             return verifier;
         }
     }
-
 }

--- a/license-check.py
+++ b/license-check.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import sys
+import os
+from pathlib import Path
+import subprocess
+
+PUBLIC_HEADER = '''
+// Copyright {YEAR} RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'''.strip().splitlines()
+
+EXTENSIONS = [
+    '.cpp',
+    '.h',
+    '.rs',
+    '.sol',
+]
+
+SKIP_DIRS = [
+    # Groth16 verifier implementation uses circom generated code under GPL3.
+    str(Path.cwd()) + "/contracts/src/groth16",
+]
+
+def check_header(expected_year, lines_actual):
+    for (expected, actual) in zip(PUBLIC_HEADER, lines_actual):
+        expected = expected.replace('{YEAR}', expected_year)
+        if expected != actual:
+            return (expected, actual)
+    return None
+
+
+def check_file(root, file):
+    cmd = ['git', 'log', '-1', '--format=%ad', '--date=format:%Y', file]
+    expected_year = subprocess.check_output(cmd, encoding='UTF-8').strip()
+    rel_path = file.relative_to(root)
+    lines = file.read_text().splitlines()
+    result = check_header(expected_year, lines)
+    if result:
+        print(f'{rel_path}: invalid header!')
+        print(f'  expected: {result[0]}')
+        print(f'    actual: {result[1]}')
+        return 1
+    return 0
+
+
+def repo_root():
+    """Return an absolute Path to the repo root"""
+    cmd = ["git", "rev-parse", "--show-toplevel"]
+    return Path(subprocess.check_output(cmd, encoding='UTF-8').strip())
+
+
+def tracked_files():
+    """Yield all file paths tracked by git"""
+    cmd = ["git", "ls-tree", "--full-tree", "--name-only", "-r", "HEAD"]
+    tree = subprocess.check_output(cmd, encoding='UTF-8').strip()
+    for path in tree.splitlines():
+        yield (repo_root() / Path(path)).absolute()
+
+
+def main():
+    root = repo_root()
+    ret = 0
+    for path in tracked_files():
+        if path.suffix in EXTENSIONS:
+            skip = False
+            for path_start in SKIP_DIRS:
+                if str(path).startswith(path_start):
+                    skip = True
+                    break
+            if skip:
+                continue
+
+            ret |= check_file(root, path)
+    sys.exit(ret)
+
+
+if __name__ == "__main__":
+    main()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt", "rust-src"]
+targets = []
+profile = "minimal"


### PR DESCRIPTION
This PR initialized CI, and fixes issues found along the way, by copying CI configurations from the `risc0` repository.
