### PR TITLE
Bump Cargo versions to 0.8.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "0.7.0-alpha.1"
+version = "0.8.0-alpha.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "0.7.0-alpha.1"
+version = "0.8.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-relay"
-version = "0.7.0-alpha.1"
+version = "0.8.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4063,14 +4063,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-relay-test-methods"
-version = "0.7.0-alpha.1"
+version = "0.8.0-alpha.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-forge-ffi"
-version = "0.7.0-alpha.1"
+version = "0.8.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["build", "contracts", "ffi", "relay", "relay/tests/methods"]
 
 [workspace.package]
-version = "0.7.0-alpha.1"
+version = "0.8.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -11,9 +11,9 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 
 [workspace.dependencies]
 # Intra-workspace dependencies
-risc0-ethereum-contracts = { version = "0.7.0-alpha.1", default-features = false, path = "contracts" }
-risc0-forge-ffi = { version = "0.7.0-alpha.1", default-features = false, path = "ffi" }
-risc0-ethereum-relay = { version = "0.7.0-alpha.1", default-features = false, path = "relay" }
+risc0-ethereum-contracts = { version = "0.8.0-alpha.1", default-features = false, path = "contracts" }
+risc0-forge-ffi = { version = "0.8.0-alpha.1", default-features = false, path = "ffi" }
+risc0-ethereum-relay = { version = "0.8.0-alpha.1", default-features = false, path = "relay" }
 
 alloy-primitives = { version = "0.6", default-features = false, features = ["rlp", "serde", "std"] }
 alloy-sol-types = { version = "0.6" }


### PR DESCRIPTION
Bump version to `0.8.0-alpha.1` to mark development post custting of `release-0.7`
