### PR TITLE
Add callout to use the latest release instead of `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]  
+> `main` is the development branch for this repository.
+> Application developers should use the [latest release](https://github.com/risc0/risc0-ethereum/releases) instead.
+
 # RISC Zero Ethereum
 
 [RISC Zero] is a zero-knowledge verifiable general computing platform, with [Ethereum] integration.


### PR DESCRIPTION
Application developers should use the latest release, instead of main, to avoid encountering issues with verifying proofs produced by Bonsai, and other integration issues.

This PR adds a callout to alert users to this