### PR TITLE
Bump version to 0.11.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-relay"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4311,14 +4311,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-relay-test-methods"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-forge-ffi"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4368,7 +4368,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["build", "contracts", "ffi", "relay", "relay/tests/methods", "steel"]
 
 [workspace.package]
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -11,11 +11,11 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 
 [workspace.dependencies]
 # Intra-workspace dependencies
-risc0-build-ethereum = { version = "0.9.0-alpha.1", default-features = false, path = "build" }
-risc0-ethereum-contracts = { version = "0.9.0-alpha.1", default-features = false, path = "contracts" }
-risc0-ethereum-relay = { version = "0.9.0-alpha.1", default-features = false, path = "relay" }
-risc0-steel = { version = "0.9.0-alpha.1", default-features = false, path = "steel" }
-risc0-forge-ffi = { version = "0.9.0-alpha.1", default-features = false, path = "ffi" }
+risc0-build-ethereum = { version = "0.11.0-alpha.1", default-features = false, path = "build" }
+risc0-ethereum-contracts = { version = "0.11.0-alpha.1", default-features = false, path = "contracts" }
+risc0-ethereum-relay = { version = "0.11.0-alpha.1", default-features = false, path = "relay" }
+risc0-steel = { version = "0.11.0-alpha.1", default-features = false, path = "steel" }
+risc0-forge-ffi = { version = "0.11.0-alpha.1", default-features = false, path = "ffi" }
 
 alloy-primitives = { version = "0.6.4", features = ["serde", "rlp", "std"] }
 alloy-rlp = { version = "0.3.4", default-features = false }

--- a/examples/erc20-counter/Cargo.lock
+++ b/examples/erc20-counter/Cargo.lock
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/examples/erc20-counter/methods/guest/Cargo.lock
+++ b/examples/erc20-counter/methods/guest/Cargo.lock
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/examples/erc20/Cargo.lock
+++ b/examples/erc20/Cargo.lock
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/examples/erc20/methods/guest/Cargo.lock
+++ b/examples/erc20/methods/guest/Cargo.lock
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.9.0-alpha.1"
+version = "0.11.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",


### PR DESCRIPTION
With release of `0.10`, bump version on `main` to `0.11.0-alpha.1`
