### PR TITLE
Pin revm-primitives to 3.1.0 for 0.10 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,6 +4382,7 @@ dependencies = [
  "nybbles",
  "once_cell",
  "revm",
+ "revm-primitives",
  "risc0-steel",
  "rlp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ log = "0.4"
 nybbles = { version = "0.2.1", features = ["serde"] }
 once_cell = "1.19"
 revm = { version = "7.2", default-features = false, features = ["std"] }
+revm-primitives = { version = "=3.1.0", default-features = false }
 risc0-build = { version = "0.21", default-features = false }
 risc0-zkp = { version = "0.21", default-features = false }
 risc0-zkvm = { version = "0.21", default-features = false }

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -19,6 +19,7 @@ log = { workspace = true, optional = true }
 nybbles = { workspace = true }
 once_cell = { workspace = true }
 revm = { workspace = true, features = ["serde"] }
+revm-primitives = { workspace = true }
 rlp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }


### PR DESCRIPTION
Pin revm-primitives to 3.1.0 for 0.10 release