### PR TITLE
Add initial version of release instructions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           python-version: "3.10"
       - run: python license-check.py
+      - name: check for "D0 NOT MERGE" comments
+        run: |
+          [ "$(grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD) | tee /dev/fd/2 | wc -l)" -eq "0" ]
 
   test:
     runs-on: [self-hosted, prod, "${{ matrix.os }}", "${{ matrix.device }}"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,12 +4,14 @@
 
    Release branches are initialized with a commit from `main`, and named `release-x.y` where `x.y` is the major and minor version.
    Patch version changes are committed to the release branch matching their major and minor version.
-    <!-- TODO: Does this work with branch protections -->
 
 2. Create two version bump PRs:
 
    * One PR should bump the version on the `release-x.y` branch.
-   * One PR should bump the version on the `main` branch to the next, unreleased, minor version.
+
+     Additionally remove the note at the top of `README.md` about being on the `main` branch.
+
+   * The other PR should bump the version on the `main` branch to the next, unreleased, minor version.
 
 3. Tag the release as `vX.Y.Z`, and add release on GitHub.
 
@@ -19,7 +21,7 @@
 
    Crates currently published to `crates.io` are:
 
-   * `risc0-ethereum-view-call`
+   * `risc0-steel`
    * `risc0-build-ethereum`
 
    > NOTE: We intend to publish more of the crates in the future.
@@ -31,7 +33,15 @@
 
     <!-- TODO: Include instructions for the process including the emergency stop and index contracts, once those are ready -->
 
-   * Deploy the contract to Sepolia.
+   * Deploy the contract to Sepolia, and verify the source code.
+
+    Set the `ETHERSCAN_API_KEY` and `ETH_WALLET_PRIVATE_KEY` environment variables to an valid Etherscan API key and Sepolia private key respectively.
+
+     ```sh
+     # In the contracts directory
+     forge script script/DeployVerifier.s.sol:DeployVerifier --rpc-url $ALCHEMY_API_URL --broadcast --verify -vvvv
+     ```
+
    * Document the new address and version in the `dev.risczero.com` docs.
-   * Verify the source code on Etherescan.
-     <!-- TODO Include instructions on how to actually do this -->
+
+     [https://dev.risczero.com/api/blockchain-integration/contracts/verifier](https://dev.risczero.com/api/blockchain-integration/contracts/verifier)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,6 +24,8 @@
    * `risc0-steel`
    * `risc0-build-ethereum`
 
+   <br/>
+
    > NOTE: We intend to publish more of the crates in the future.
    > Blocking issue is that the other crates depend on building Solidity smart contracts as part of a `build.rs` script, which makes it incompatible with `crates.io`.
 
@@ -35,7 +37,7 @@
 
    * Deploy the contract to Sepolia, and verify the source code.
 
-    Set the `ETHERSCAN_API_KEY` and `ETH_WALLET_PRIVATE_KEY` environment variables to an valid Etherscan API key and Sepolia private key respectively.
+     Set the `ETHERSCAN_API_KEY` and `ETH_WALLET_PRIVATE_KEY` environment variables to an valid Etherscan API key and Sepolia private key respectively.
 
      ```sh
      # In the contracts directory

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,37 @@
+# Release process
+
+1. For a major or minor release, create a release branch.
+
+   Release branches are initialized with a commit from `main`, and named `release-x.y` where `x.y` is the major and minor version.
+   Patch version changes are committed to the release branch matching their major and minor version.
+    <!-- TODO: Does this work with branch protections -->
+
+2. Create two version bump PRs:
+
+   * One PR should bump the version on the `release-x.y` branch.
+   * One PR should bump the version on the `main` branch to the next, unreleased, minor version.
+
+3. Tag the release as `vX.Y.Z`, and add release on GitHub.
+
+   Include a summary of the changes in the release notes.
+
+4. Publish crates to `crates.io`
+
+   Crates currently published to `crates.io` are:
+
+   * `risc0-ethereum-view-call`
+   * `risc0-build-ethereum`
+
+   > NOTE: We intend to publish more of the crates in the future.
+   > Blocking issue is that the other crates depend on building Solidity smart contracts as part of a `build.rs` script, which makes it incompatible with `crates.io`.
+
+   <!-- TODO: Include the actual commands to publish -->
+
+5. When changes have been made to the verifier contract, deploy a new verifier contract.
+
+    <!-- TODO: Include instructions for the process including the emergency stop and index contracts, once those are ready -->
+
+   * Deploy the contract to Sepolia.
+   * Document the new address and version in the `dev.risczero.com` docs.
+   * Verify the source code on Etherescan.
+     <!-- TODO Include instructions on how to actually do this -->

--- a/contracts/script/DeployVerifier.s.sol
+++ b/contracts/script/DeployVerifier.s.sol
@@ -33,7 +33,7 @@ contract DeployVerifier is Script {
 
         vm.startBroadcast(deployerKey);
 
-        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1);
+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1, ControlID.BN254_CONTROL_ID);
         console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));
 
         vm.stopBroadcast();

--- a/contracts/script/DeployVerifier.s.sol
+++ b/contracts/script/DeployVerifier.s.sol
@@ -33,7 +33,8 @@ contract DeployVerifier is Script {
 
         vm.startBroadcast(deployerKey);
 
-        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1, ControlID.BN254_CONTROL_ID);
+        IRiscZeroVerifier verifier =
+            new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1, ControlID.BN254_CONTROL_ID);
         console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));
 
         vm.stopBroadcast();

--- a/contracts/script/DeployVerifier.s.sol
+++ b/contracts/script/DeployVerifier.s.sol
@@ -1,0 +1,41 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {IRiscZeroVerifier} from "../src//IRiscZeroVerifier.sol";
+import {ControlID, RiscZeroGroth16Verifier} from "../src/groth16/RiscZeroGroth16Verifier.sol";
+
+/// @notice Deployment script for the RISC Zero verifier.
+/// @dev Use the following environment variable to control the deployment:
+///     * ETH_WALLET_PRIVATE_KEY private key of the wallet to be used for deployment.
+///
+/// See the Foundry documentation for more information about Solidity scripts.
+/// https://book.getfoundry.sh/tutorials/solidity-scripting
+contract DeployVerifier is Script {
+    function run() external {
+        uint256 deployerKey = uint256(vm.envBytes32("ETH_WALLET_PRIVATE_KEY"));
+
+        vm.startBroadcast(deployerKey);
+
+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1);
+        console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/src/RiscZeroCheats.sol
+++ b/contracts/src/RiscZeroCheats.sol
@@ -70,11 +70,8 @@ abstract contract RiscZeroCheats is CommonBase {
             console2.log("Deployed RiscZeroGroth16VerifierTest to", address(verifier));
             return verifier;
         } else {
-            IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(
-                ControlID.CONTROL_ID_0,
-                ControlID.CONTROL_ID_1,
-                ControlID.BN254_CONTROL_ID
-            );
+            IRiscZeroVerifier verifier =
+                new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1, ControlID.BN254_CONTROL_ID);
             console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));
             return verifier;
         }

--- a/contracts/src/relay/BonsaiRelayTest.sol
+++ b/contracts/src/relay/BonsaiRelayTest.sol
@@ -47,16 +47,11 @@ abstract contract BonsaiRelayTest is Test, BonsaiRelayCheats {
             // Use a long and unweildy environment variable name for overriding
             // the expected chain ID for the test relay so that it is hard to
             // trigger without thinking about it.
-            bonsaiTestRelay = new BonsaiTestRelay(
-                vm.envOr("BONSAI_TEST_RELAY_EXPECTED_CHAIN_ID", uint256(31337))
-            );
+            bonsaiTestRelay = new BonsaiTestRelay(vm.envOr("BONSAI_TEST_RELAY_EXPECTED_CHAIN_ID", uint256(31337)));
             bonsaiRelay = new BonsaiRelayQueueWrapper(bonsaiTestRelay);
         } else {
-            IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(
-                ControlID.CONTROL_ID_0,
-                ControlID.CONTROL_ID_1,
-                ControlID.BN254_CONTROL_ID
-            );
+            IRiscZeroVerifier verifier =
+                new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1, ControlID.BN254_CONTROL_ID);
             bonsaiVerifyingRelay = new BonsaiRelay(verifier);
             bonsaiRelay = new BonsaiRelayQueueWrapper(bonsaiVerifyingRelay);
         }

--- a/contracts/test/RiscZeroGroth16Verifier.t.sol
+++ b/contracts/test/RiscZeroGroth16Verifier.t.sol
@@ -50,11 +50,8 @@ contract RiscZeroGroth16VerifierTest is Test {
     IRiscZeroVerifier internal verifier;
 
     function setUp() external {
-        verifier = new RiscZeroGroth16Verifier(
-            ControlID.CONTROL_ID_0,
-            ControlID.CONTROL_ID_1,
-            ControlID.BN254_CONTROL_ID
-        );
+        verifier =
+            new RiscZeroGroth16Verifier(ControlID.CONTROL_ID_0, ControlID.CONTROL_ID_1, ControlID.BN254_CONTROL_ID);
     }
 
     function testVerifyKnownGoodReceipt() external view {


### PR DESCRIPTION
This PR adds an initial version of release instructions to `RELEASE.md`.
It additionally adds a deploy script for the `RiscZeroGroth16Verifier` contract.

Resolves: https://github.com/risc0/risc0-ethereum/issues/76
