### PR TITLE
Add documentation for the contract version management solution

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -21,6 +21,21 @@ The two main contracts you need to start verifing receipts on Ethereum are:
   This is the verifier contract for [RISC Zero's Groth16 proof implementation][groth16-article].
   It is the first verifier implementation we have implemented for on-chain verification, and this is the contract you will use in your deployed application.
 
+* [`RiscZeroEmergencyStop`]
+
+    This contract acts as a proxy for an [`IRiscZeroVerifier`] contract, with the addition of an emergency stop function.
+    When the emergency stop is activated, this proxy will be permanently disabled, and revert on all verify calls.
+
+* [`RiscZeroEmergencyStop`]
+
+    Allows for multiple verifier implementations to live behind a single address implementing the [`IRiscZeroVerifier`] interface.
+    Using the verifier selector included in the seal, it will route each `verify` call to the appropriate implementation.
+
+## Verifier Upgrades and Deprecation
+
+The [`RiscZeroEmergencyStop`] and [`RiscZeroVerifierRouter`] contracts are used to implement a version management system, with appropriate safeguards in place.
+You can read more about the version management design in the [version management design](./version-management-design.md).
+
 ## Using the Contracts with Foundry
 
 You can use these contracts in [Foundry] using the `forge install` command to add this repository as a [dependency][foundry-dependencies].
@@ -36,4 +51,6 @@ forge install risc0/risc0-ethereum
 [foundry-dependencies]: https://book.getfoundry.sh/projects/dependencies
 [`IRiscZeroVerifier`]: ./src/IRiscZeroVerifier.sol
 [`RiscZeroGroth16Verifier`]: ./src/groth16/Groth16Verifier.sol
+[`RiscZeroEmergencyStop`]: ./src/groth16/RiscZeroEmergencyStop.sol
+[`RiscZeroVerifierRouter`]: ./src/groth16/RiscZeroVerifierRouter.sol
 [groth16-article]: https://www.risczero.com/news/on-chain-verification

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -51,6 +51,6 @@ forge install risc0/risc0-ethereum
 [foundry-dependencies]: https://book.getfoundry.sh/projects/dependencies
 [`IRiscZeroVerifier`]: ./src/IRiscZeroVerifier.sol
 [`RiscZeroGroth16Verifier`]: ./src/groth16/Groth16Verifier.sol
-[`RiscZeroEmergencyStop`]: ./src/groth16/RiscZeroEmergencyStop.sol
-[`RiscZeroVerifierRouter`]: ./src/groth16/RiscZeroVerifierRouter.sol
+[`RiscZeroEmergencyStop`]: ./src/RiscZeroEmergencyStop.sol
+[`RiscZeroVerifierRouter`]: ./src/RiscZeroVerifierRouter.sol
 [groth16-article]: https://www.risczero.com/news/on-chain-verification

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -21,19 +21,19 @@ The two main contracts you need to start verifing receipts on Ethereum are:
   This is the verifier contract for [RISC Zero's Groth16 proof implementation][groth16-article].
   It is the first verifier implementation we have implemented for on-chain verification, and this is the contract you will use in your deployed application.
 
-* [`RiscZeroEmergencyStop`]
+* [`RiscZeroVerifierEmergencyStop`]
 
     This contract acts as a proxy for an [`IRiscZeroVerifier`] contract, with the addition of an emergency stop function.
     When the emergency stop is activated, this proxy will be permanently disabled, and revert on all verify calls.
 
-* [`RiscZeroEmergencyStop`]
+* [`RiscZeroVerifierRouter`]
 
     Allows for multiple verifier implementations to live behind a single address implementing the [`IRiscZeroVerifier`] interface.
     Using the verifier selector included in the seal, it will route each `verify` call to the appropriate implementation.
 
 ## Verifier Upgrades and Deprecation
 
-The [`RiscZeroEmergencyStop`] and [`RiscZeroVerifierRouter`] contracts are used to implement a version management system, with appropriate safeguards in place.
+The [`RiscZeroVerifierEmergencyStop`] and [`RiscZeroVerifierRouter`] contracts are used to implement a version management system, with appropriate safeguards in place.
 You can read more about the version management design in the [version management design](./version-management-design.md).
 
 ## Using the Contracts with Foundry
@@ -51,6 +51,6 @@ forge install risc0/risc0-ethereum
 [foundry-dependencies]: https://book.getfoundry.sh/projects/dependencies
 [`IRiscZeroVerifier`]: ./src/IRiscZeroVerifier.sol
 [`RiscZeroGroth16Verifier`]: ./src/groth16/Groth16Verifier.sol
-[`RiscZeroEmergencyStop`]: ./src/RiscZeroEmergencyStop.sol
+[`RiscZeroVerifierEmergencyStop`]: ./src/RiscZeroVerifierEmergencyStop.sol
 [`RiscZeroVerifierRouter`]: ./src/RiscZeroVerifierRouter.sol
 [groth16-article]: https://www.risczero.com/news/on-chain-verification

--- a/contracts/src/RiscZeroVerifierEmergencyStop.sol
+++ b/contracts/src/RiscZeroVerifierEmergencyStop.sol
@@ -34,17 +34,19 @@ contract RiscZeroVerifierEmergencyStop is IRiscZeroVerifier, Ownable, Pausable {
     }
 
     /// @notice Initiate an emergency stop of the wrapped verifier contract.
-    ///         This method can only be used by guardian address assigned as owner of this contract.
+    ///         Can only be used by the guardian address assigned as owner of this contract.
+    ///
     ///         When stopped, all calls to the verify and verifyIntegrity functions will revert.
     ///         Once stopped, this contract can never be restarted.
     function estop() external onlyOwner {
         _pause();
     }
 
-    /// @notice Initiate an emergency stop of the wrapped verifier contract.
+    /// @notice Initiate an emergency stop of the wrapped verifier contract, via the circuit breaker.
     ///         This method can be called by anyone who can produce a verifying proof for a receipt
     ///         claim digest of all zeroes. The existence of such a proof demonstrates a critical
     ///         vulnerability in the proof system.
+    ///
     ///         When stopped, all calls to the verify and verifyIntegrity functions will revert.
     ///         Once stopped, this contract can never be restarted.
     function estop(Receipt calldata receipt) external {

--- a/contracts/src/RiscZeroVerifierEmergencyStop.sol
+++ b/contracts/src/RiscZeroVerifierEmergencyStop.sol
@@ -33,7 +33,7 @@ contract RiscZeroVerifierEmergencyStop is IRiscZeroVerifier, Ownable, Pausable {
         verifier = _verifier;
     }
 
-    /// @notice Initiate an emergency stop of the wrapped verifier contract.
+    /// @notice Initiate an emergency stop of the verifier contract.
     ///         Can only be used by the guardian address assigned as owner of this contract.
     ///
     ///         When stopped, all calls to the verify and verifyIntegrity functions will revert.
@@ -42,7 +42,7 @@ contract RiscZeroVerifierEmergencyStop is IRiscZeroVerifier, Ownable, Pausable {
         _pause();
     }
 
-    /// @notice Initiate an emergency stop of the wrapped verifier contract, via the circuit breaker.
+    /// @notice Initiate an emergency stop of the verifier contract, via the "circuit breaker".
     ///         This method can be called by anyone who can produce a verifying proof for a receipt
     ///         claim digest of all zeroes. The existence of such a proof demonstrates a critical
     ///         vulnerability in the proof system.

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -17,18 +17,27 @@ flowchart LR
     router["RiscZeroVerifierRouter [managed]"]
     appRouter["RiscZeroVerifierRouter [app]"]
     
-    subgraph impls[RiscZeroEmergencyStop]
-      groth16v1["RiscZeroGroth16Verifier [v1]"]
-      aggv1["RiscZeroAggregateVerifier [v1]"]
-      groth16v2["RiscZeroGroth16Verifier [v2]"]
-
-      fflonkv1["RiscZeroFflonkVerifier [v1]"]
+    subgraph emergencyStops["Emergency Stop Proxies"]
+      groth16v1ES["RiscZeroEmergencyStop"]
+      aggv1ES["RiscZeroEmergencyStop"]
+      groth16v2ES["RiscZeroEmergencyStop"]
+      fflonkv1ES["RiscZeroEmergencyStop"]
     end
+    
+    groth16v1["RiscZeroGroth16Verifier [v1]"]
+    aggv1["RiscZeroAggregateVerifier [v1]"]
+    groth16v2["RiscZeroGroth16Verifier [v2]"]
+    fflonkv1["RiscZeroFflonkVerifier [v1]"]
 
-    router --> groth16v1
-    router & appRouter --> groth16v2
-    router --> aggv1
-    router & appRouter --> fflonkv1
+    router --> groth16v1ES
+    router & appRouter --> groth16v2ES
+    router --> aggv1ES
+    router & appRouter --> fflonkv1ES
+    
+    groth16v1ES --> groth16v1
+    groth16v2ES --> groth16v2
+    aggv1ES --> aggv1
+    fflonkv1ES --> fflonkv1
   end
   timelock[TimelockController]
   multisig["RISC Zero Multisig"]
@@ -37,7 +46,7 @@ flowchart LR
   timelock -- admin --> router
   appAdmin -- admin --> appRouter
   multisig -- proposer --> timelock
-  multisig -- guardian --> impls
+  multisig -- guardian --> emergencyStops
 ```
 
 ### Base verifier implementations

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -29,15 +29,15 @@ flowchart LR
     groth16v2["RiscZeroGroth16Verifier [v2]"]
     fflonkv1["RiscZeroFflonkVerifier [v1]"]
 
-    router --> groth16v1ES
-    router & appRouter --> groth16v2ES
-    router --> aggv1ES
-    router & appRouter --> fflonkv1ES
+    router -- calls --> groth16v1ES
+    router & appRouter -- calls --> groth16v2ES
+    router -- calls --> aggv1ES
+    router & appRouter -- calls --> fflonkv1ES
     
-    groth16v1ES --> groth16v1
-    groth16v2ES --> groth16v2
-    aggv1ES --> aggv1
-    fflonkv1ES --> fflonkv1
+    groth16v1ES -- calls --> groth16v1
+    groth16v2ES -- calls --> groth16v2
+    aggv1ES -- calls --> aggv1
+    fflonkv1ES -- calls --> fflonkv1
   end
   timelock[TimelockController]
   multisig["RISC Zero Multisig"]

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -14,8 +14,10 @@ title: Smart Contract Relationships
 ---
 flowchart LR
   subgraph IRiscZeroVerifier
-    router["RiscZeroVerifierRouter [managed]"]
-    appRouter["RiscZeroVerifierRouter [app]"]
+    subgraph emergencyStops["Routers"]
+        router["RiscZeroVerifierRouter [managed]"]
+        appRouter["RiscZeroVerifierRouter [app]"]
+    end
     
     subgraph emergencyStops["Emergency Stop Proxies"]
       groth16v1ES["RiscZeroEmergencyStop"]
@@ -24,10 +26,12 @@ flowchart LR
       fflonkv1ES["RiscZeroEmergencyStop"]
     end
     
-    groth16v1["RiscZeroGroth16Verifier [v1]"]
-    aggv1["RiscZeroAggregateVerifier [v1]"]
-    groth16v2["RiscZeroGroth16Verifier [v2]"]
-    fflonkv1["RiscZeroFflonkVerifier [v1]"]
+    subgraph emergencyStops["Base Implementations"]
+        groth16v1["RiscZeroGroth16Verifier [v1]"]
+        aggv1["RiscZeroAggregateVerifier [v1]"]
+        groth16v2["RiscZeroGroth16Verifier [v2]"]
+        fflonkv1["RiscZeroFflonkVerifier [v1]"]
+    end
 
     router -- calls --> groth16v1ES
     router & appRouter -- calls --> groth16v2ES

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -14,19 +14,19 @@ title: Smart Contract Relationships
 ---
 flowchart LR
   subgraph IRiscZeroVerifier
-    subgraph emergencyStops["Routers"]
+    subgraph routers["Routers"]
         router["RiscZeroVerifierRouter [managed]"]
         appRouter["RiscZeroVerifierRouter [app]"]
     end
-    
+
     subgraph emergencyStops["Emergency Stop Proxies"]
       groth16v1ES["RiscZeroEmergencyStop"]
       aggv1ES["RiscZeroEmergencyStop"]
       groth16v2ES["RiscZeroEmergencyStop"]
       fflonkv1ES["RiscZeroEmergencyStop"]
     end
-    
-    subgraph emergencyStops["Base Implementations"]
+
+    subgraph impls["Base Implementations"]
         groth16v1["RiscZeroGroth16Verifier [v1]"]
         aggv1["RiscZeroAggregateVerifier [v1]"]
         groth16v2["RiscZeroGroth16Verifier [v2]"]
@@ -37,7 +37,7 @@ flowchart LR
     router & appRouter -- calls --> groth16v2ES
     router -- calls --> aggv1ES
     router & appRouter -- calls --> fflonkv1ES
-    
+
     groth16v1ES -- calls --> groth16v1
     groth16v2ES -- calls --> groth16v2
     aggv1ES -- calls --> aggv1
@@ -46,7 +46,7 @@ flowchart LR
   timelock[TimelockController]
   multisig["RISC Zero Multisig"]
   appAdmin[App Admin]
-  
+
   timelock -- admin --> router
   appAdmin -- admin --> appRouter
   multisig -- proposer --> timelock

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -1,0 +1,102 @@
+# On-Chain Verifier Upgrade and Deprecation
+
+At base, the RISC Zero verifier contracts are designed to be immutable and stateless.
+This meets the highest standards for trust minimized application on Ethereum, as no action can alter the operation of the verifier.
+
+However, in the event that a security vulnerability is discovered in the verifier contract(s), stateless contracts require the application to respond to maintain security.
+As a countermeasure to this risk, and to allow for upgrades with new features on an opt-in basis, the following version management system is deployed to Ethereum.
+
+## Overview
+
+```mermaid
+---
+title: Smart Contract Relationships
+---
+flowchart LR
+  subgraph IRiscZeroVerifier
+    mux["RiscZeroVerifierMux [managed]"]
+    appMux["RiscZeroVerifierMux [app]"]
+    
+    subgraph impls[RiscZeroEmergencyStop]
+      groth16v1["RiscZeroGroth16Verifier [v1]"]
+      aggv1["RiscZeroAggregateVerifier [v1]"]
+      groth16v2["RiscZeroGroth16Verifier [v2]"]
+
+      fflonkv1["RiscZeroFflonkVerifier [v1]"]
+    end
+
+    mux --> groth16v1
+    mux & appMux --> groth16v2
+    mux --> aggv1
+    mux & appMux --> fflonkv1
+  end
+  timelock[TimelockController]
+  multisig["RISC Zero Multisig"]
+  appAdmin[App Admin]
+  
+  timelock -- owner --> mux
+  appAdmin -- owner --> appMux
+  multisig -- proposer --> timelock
+  multisig -- guardian --> impls
+```
+
+### Base verifier implementations
+
+Base verifier implementations, such as [RiscZeroGroth16Verifier](./src/groth16/RiscZeroGroth16Verifier.sol), implement cryptographic verification of proofs.
+Verifier implementations are generally implemented to be stateless and immutable.
+Each base implementation has an associated 4-byte selector value, derived from a hash of a label and it's parameters (e.g. Groth16 vkey, and RISC Zero [control root][term-control-root]).
+
+More verifier contracts will be deployed over time, and may add new zkVM circuits, recursion programs, proof systems (e.g. fflonk), batching methods etc.
+
+### Emergency stop
+
+Each base verifier can have an associated [RiscZeroEmergencyStop](./src/RiscZeroVerifierEmergencyStop.sol) contract.
+This contract acts as a proxy, with the addition of an emergency stop function.
+When the emergency stop is activated, this proxy will be permanently disabled, and revert on all verify calls.
+
+There are two ways to trigger the emergency stop:
+
+- A call from a designated "guardian" address.
+- Activating the "circuit breaker" by proving the existence of a critical vulnerability in the RISC Zero proof system.
+
+RISC Zero deploys and acts as guardian on an emergency stop contract for each of its deployed verifier contracts.
+Application developers may also deploy and use their own emergency stop contracts, on which they can assign themselves as guardian.
+
+### Router
+
+A [RiscZeroVerifierRouter](./src/RiscZeroVerifierRouter.sol) allows for multiple verifier implementations to live behind a single address implementing the [IRiscZeroVerifier](./src/IRiscZeroVerifier.sol) interface.
+Using the verifier selector included in the seal, it will route each `verify` call to the appropriate implementation.
+
+Implementations can be added to the router mapping by an admin of the router, who is assigned as the owner of the contract.
+Implementations can also be removed by the admin, and once removed it can never be replaced. I.e. each identifier can have at most one implementation across time.
+
+RISC Zero deploys and acts as admin on a router, maintaining a recommended list of trusted verifiers.
+Note in particular this means that RISC Zero may add new verifiers, and so a [TimelockController][TimelockController-docs] is put in place to impose a delay on all additions.
+If an application using the managed router does not trust a new verifier being added, they will have a time-window to respond.
+
+Applications that require control over the list of accepted verifiers, and want to managed their own list can deploy their own router, pointing to a subset (or disjoint set) of the RISC Zero verifier implementations.
+
+## Usage patterns
+
+Different applications will have different requirements and restrictions on which version of the zkVM they want to accept.
+
+Here are some available usage patterns:
+
+- Use a specific, immutable, and stateless version of the RISC Zero verifier.
+
+  Using `RiscZeroGroth16Verifier` directly accomplishes this.
+  It has no state, it cannot be upgraded and it cannot be shutdown, even in the event of vulnerabilities.
+  It is up to the application to provide a version management strategy.
+
+- Use a specific version of the RISC Zero verifier, with a shutdown mechanism.
+
+  Using a `RiscZeroEmergencyStop` contract as a proxy to the verifier accomplishes this.
+  Application developers can choose to use an emergency stop proxy deployed and managed by RISC Zero, or can deploy their own.
+
+- Use a list of RISC Zero verifiers, with the ability to add and remove versions from the list. Each version may also support emergency shutdown.
+
+  Using a `RiscZeroVerifierRouter` accomplishes this.
+  Applications developers can choose to use the router deployed and managed by RISC Zero, or may deploy their own.
+
+[term-control-root]: https://dev.risczero.com/terminology#control-root
+[TimelockController-docs]: https://docs.openzeppelin.com/contracts/5.x/api/governance#TimelockController

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -20,10 +20,10 @@ flowchart LR
     end
 
     subgraph emergencyStops["Emergency Stop Proxies"]
-      groth16v1ES["RiscZeroEmergencyStop"]
-      aggv1ES["RiscZeroEmergencyStop"]
-      groth16v2ES["RiscZeroEmergencyStop"]
-      fflonkv1ES["RiscZeroEmergencyStop"]
+      groth16v1ES["RiscZeroVerifierEmergencyStop"]
+      aggv1ES["RiscZeroVerifierEmergencyStop"]
+      groth16v2ES["RiscZeroVerifierEmergencyStop"]
+      fflonkv1ES["RiscZeroVerifierEmergencyStop"]
     end
 
     subgraph impls["Base Implementations"]
@@ -63,7 +63,7 @@ More verifier contracts will be deployed over time, and may add new zkVM circuit
 
 ### Emergency stop
 
-Each base verifier can have an associated [RiscZeroEmergencyStop](./src/RiscZeroVerifierEmergencyStop.sol) contract.
+Each base verifier can have an associated [RiscZeroVerifierEmergencyStop](./src/RiscZeroVerifierEmergencyStop.sol) contract.
 This contract acts as a proxy, with the addition of an emergency stop function.
 When the emergency stop is activated, this proxy will be permanently disabled, and revert on all verify calls.
 
@@ -103,7 +103,7 @@ Here are some available usage patterns:
 
 - Use a specific version of the RISC Zero verifier, with a shutdown mechanism.
 
-  Using a `RiscZeroEmergencyStop` contract as a proxy to the verifier accomplishes this.
+  Using a `RiscZeroVerifierEmergencyStop` contract as a proxy to the verifier accomplishes this.
   Application developers can choose to use an emergency stop proxy deployed and managed by RISC Zero, or can deploy their own.
 
 - Use a list of RISC Zero verifiers, with the ability to add and remove versions from the list. Each version may also support emergency shutdown.

--- a/contracts/version-management-design.md
+++ b/contracts/version-management-design.md
@@ -14,8 +14,8 @@ title: Smart Contract Relationships
 ---
 flowchart LR
   subgraph IRiscZeroVerifier
-    mux["RiscZeroVerifierMux [managed]"]
-    appMux["RiscZeroVerifierMux [app]"]
+    router["RiscZeroVerifierRouter [managed]"]
+    appRouter["RiscZeroVerifierRouter [app]"]
     
     subgraph impls[RiscZeroEmergencyStop]
       groth16v1["RiscZeroGroth16Verifier [v1]"]
@@ -25,17 +25,17 @@ flowchart LR
       fflonkv1["RiscZeroFflonkVerifier [v1]"]
     end
 
-    mux --> groth16v1
-    mux & appMux --> groth16v2
-    mux --> aggv1
-    mux & appMux --> fflonkv1
+    router --> groth16v1
+    router & appRouter --> groth16v2
+    router --> aggv1
+    router & appRouter --> fflonkv1
   end
   timelock[TimelockController]
   multisig["RISC Zero Multisig"]
   appAdmin[App Admin]
   
-  timelock -- owner --> mux
-  appAdmin -- owner --> appMux
+  timelock -- admin --> router
+  appAdmin -- admin --> appRouter
   multisig -- proposer --> timelock
   multisig -- guardian --> impls
 ```


### PR DESCRIPTION
This PR adds documentation describing the design of the verifier contract version management solution implemented in https://github.com/risc0/risc0-ethereum/pull/80. It is intended to provide detailed information to help security-minded application developers make an informed decision about how to use the verifier contracts.
