### PR TITLE
Rename ReceiptClaimLib.from to ReceiptClaimLib.ok

### DIFF
--- a/contracts/src/IRiscZeroVerifier.sol
+++ b/contracts/src/IRiscZeroVerifier.sol
@@ -78,7 +78,7 @@ library ReceiptClaimLib {
     /// @dev Input hash and postStateDigest are set to all-zeros (i.e. no committed input, or
     ///      final memory state), the exit code is (Halted, 0), and there are no assumptions
     ///      (i.e. the receipt is unconditional).
-    function from(bytes32 imageId, bytes32 journalDigest) internal pure returns (ReceiptClaim memory) {
+    function ok(bytes32 imageId, bytes32 journalDigest) internal pure returns (ReceiptClaim memory) {
         return ReceiptClaim(
             imageId,
             SYSTEM_STATE_ZERO_DIGEST,

--- a/contracts/src/groth16/RiscZeroGroth16Verifier.sol
+++ b/contracts/src/groth16/RiscZeroGroth16Verifier.sol
@@ -138,7 +138,7 @@ contract RiscZeroGroth16Verifier is IRiscZeroVerifier, Groth16Verifier {
 
     /// @inheritdoc IRiscZeroVerifier
     function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) external view {
-        _verifyIntegrity(seal, ReceiptClaimLib.from(imageId, journalDigest).digest());
+        _verifyIntegrity(seal, ReceiptClaimLib.ok(imageId, journalDigest).digest());
     }
 
     /// @inheritdoc IRiscZeroVerifier

--- a/contracts/src/test/RiscZeroMockVerifier.sol
+++ b/contracts/src/test/RiscZeroMockVerifier.sol
@@ -52,7 +52,7 @@ contract RiscZeroMockVerifier is IRiscZeroVerifier {
 
     /// @inheritdoc IRiscZeroVerifier
     function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) public view {
-        _verifyIntegrity(seal, ReceiptClaimLib.from(imageId, journalDigest).digest());
+        _verifyIntegrity(seal, ReceiptClaimLib.ok(imageId, journalDigest).digest());
     }
 
     /// @inheritdoc IRiscZeroVerifier
@@ -77,7 +77,7 @@ contract RiscZeroMockVerifier is IRiscZeroVerifier {
 
     /// @notice Construct a mock receipt for the given image ID and journal.
     function mockProve(bytes32 imageId, bytes32 journalDigest) public view returns (Receipt memory) {
-        return mockProve(ReceiptClaimLib.from(imageId, journalDigest).digest());
+        return mockProve(ReceiptClaimLib.ok(imageId, journalDigest).digest());
     }
 
     /// @notice Construct a mock receipt for the given claim digest.

--- a/contracts/test/RiscZeroVerifierEmergencyStop.t.sol
+++ b/contracts/test/RiscZeroVerifierEmergencyStop.t.sol
@@ -45,7 +45,7 @@ contract RiscZeroVerifierEmergencyStopTest is Test {
     RiscZeroVerifierEmergencyStop internal verifierEstop;
 
     bytes32 internal TEST_JOURNAL_DIGEST = sha256(TestReceipt.JOURNAL);
-    ReceiptClaim internal TEST_RECEIPT_CLAIM = ReceiptClaimLib.from(TestReceipt.IMAGE_ID, TEST_JOURNAL_DIGEST);
+    ReceiptClaim internal TEST_RECEIPT_CLAIM = ReceiptClaimLib.ok(TestReceipt.IMAGE_ID, TEST_JOURNAL_DIGEST);
     RiscZeroReceipt internal TEST_RECEIPT;
 
     function setUp() external {

--- a/contracts/test/RiscZeroVerifierRouter.t.sol
+++ b/contracts/test/RiscZeroVerifierRouter.t.sol
@@ -41,7 +41,7 @@ contract RiscZeroVerifierEmergencyStopTest is Test {
     using ReceiptClaimLib for ReceiptClaim;
 
     bytes32 internal TEST_JOURNAL_DIGEST = sha256(TestReceipt.JOURNAL);
-    ReceiptClaim internal TEST_RECEIPT_CLAIM = ReceiptClaimLib.from(TestReceipt.IMAGE_ID, TEST_JOURNAL_DIGEST);
+    ReceiptClaim internal TEST_RECEIPT_CLAIM = ReceiptClaimLib.ok(TestReceipt.IMAGE_ID, TEST_JOURNAL_DIGEST);
     RiscZeroReceipt internal TEST_RECEIPT_A;
     RiscZeroReceipt internal TEST_RECEIPT_B;
     RiscZeroReceipt internal TEST_MANGLED_RECEIPT_A;


### PR DESCRIPTION
Rename `ReceiptClaimLib.from` to `ReceiptClaimLib.ok` to match recent API changes to `risc0`.

https://github.com/risc0/risc0/blob/c393f590b68cfd1dd0d8d167b9d6833ef832d428/risc0/zkvm/src/receipt_claim.rs#L68-L73
