### PR TITLE
Bump development version to 1.1.0-alpha.1 and remove warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 [workspace.dependencies]
 # Intra-workspace dependencies
 risc0-build-ethereum = { version = "1.1.0-alpha.1", default-features = false, path = "build" }
-risc0-ethereum-contracts = { version = "0.12.0-alpha.1", default-features = false, path = "contracts" }
-risc0-steel = { version = "1.1.0-alpha.1", default-features = false, path = "steel" }
+risc0-ethereum-contracts = { version = "1.1.0-alpha.1", default-features = false, path = "contracts" }
+risc0-steel = { version = "0.12.0-alpha.1", default-features = false, path = "steel" }
 risc0-forge-ffi = { version = "1.1.0-alpha.1", default-features = false, path = "ffi" }
 
 # risc0 monorepo dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["build", "contracts", "ffi", "steel"]
 
 [workspace.package]
-version = "0.11.0-alpha.1"
+version = "1.1.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -11,10 +11,10 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 
 [workspace.dependencies]
 # Intra-workspace dependencies
-risc0-build-ethereum = { version = "0.11.0-alpha.1", default-features = false, path = "build" }
-risc0-ethereum-contracts = { version = "0.11.0-alpha.1", default-features = false, path = "contracts" }
-risc0-steel = { version = "0.11.0-alpha.1", default-features = false, path = "steel" }
-risc0-forge-ffi = { version = "0.11.0-alpha.1", default-features = false, path = "ffi" }
+risc0-build-ethereum = { version = "1.1.0-alpha.1", default-features = false, path = "build" }
+risc0-ethereum-contracts = { version = "0.12.0-alpha.1", default-features = false, path = "contracts" }
+risc0-steel = { version = "1.1.0-alpha.1", default-features = false, path = "steel" }
+risc0-forge-ffi = { version = "1.1.0-alpha.1", default-features = false, path = "ffi" }
 
 # risc0 monorepo dependencies.
 risc0-build = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false }

--- a/examples/erc20/README.md
+++ b/examples/erc20/README.md
@@ -2,8 +2,6 @@
 
 **An example that uses the ERC20 interface's `balanceOf` method.**
 
-> ***WARNING***: This software is still experimental, we do not recommend it for production use.
-
 ## Prerequisites
 
 To get started, you need to have Rust installed. If you haven't done so, follow the instructions [here][install-rust].

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-steel"
 description = "Query Ethereum state, or any other EVM-based blockchain state within the RISC Zero zkVM."
-version = { workspace = true }
+version = "0.12.0-alpha.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/steel/README.md
+++ b/steel/README.md
@@ -2,7 +2,9 @@
 
 # Steel - Hardened off-chain Execution for EVM dapps
 
-> ***WARNING***: This library is still in its experimental phase and under active development. Production use is not recommended until the software has matured sufficiently.
+> [!WARNING]
+> This library is under active development, with breaking changes expected.
+> We do not recommend the Steel library for production use at this time.
 
 In the realm of Ethereum and smart contracts, obtaining data directly from the blockchain without altering its state—known as "view calls" — are a fundamental operation.
 Traditionally, these operations, especially when it comes to proving and verifying off-chain computations, involve a degree of complexity: either via proof of storage mechanisms requiring detailed knowledge of slot indexes, or via query-specific circuit development.

--- a/steel/README.md
+++ b/steel/README.md
@@ -2,7 +2,7 @@
 
 # Steel - Hardened off-chain Execution for EVM dapps
 
-> [!WARNING]
+> ***WARNING***
 > This library is under active development, with breaking changes expected.
 > We do not recommend the Steel library for production use at this time.
 


### PR DESCRIPTION
This PR removes warnings about not being recommended for production use from all remaining places expect `risc0-steel` where the warning is softened.

It also bumps the development version to 1.1.0-alpha.1 to coincide with 1.0.0 release