### PR TITLE
Add a rerun if output to try to invalidate the build cache when sol files change

### DIFF
--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -19,6 +19,10 @@ use std::process::Command;
 use anyhow::Context;
 
 fn main() -> anyhow::Result<()> {
+    // Rerun the build script if anything in the src folder has changed, and in particular if any
+    // of the Solidity source files have changed.
+    println!("cargo::rerun-if-changed=src");
+
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let out_dir = std::path::Path::new(&out_dir);
     let cache_dir = out_dir.join(".cache");


### PR DESCRIPTION
An attempt to resolve the issues with https://github.com/risc0/risc0-ethereum/issues/106 by adding a `rerun-if` output to the `build.rs` script