### PR TITLE
Rectify typographical inaccuracies

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Options {
 }
 
 // Builder interface is provided to make it easy to add more intelligent default and additional
-// options without breaking backwards compatibility in the future.
+// options without breaking backward compatibility in the future.
 impl Options {
     /// Add a path to generate the Solidity file with image ID information.
     pub fn with_image_id_sol_path(mut self, path: impl AsRef<Path>) -> Self {

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -67,7 +67,7 @@ export FIREBLOCKS_API_BASE_URL="https://sandbox-api.fireblocks.io"
 Then, in the instructions below, pass the `--fireblocks` flag to the `manage` script.
 
 > [!NOTE]
-> Your Fireblocks API user will need to have "Editor" permissions (i.e., ability to propose transactions for signing, but not necessarily the ability to sign transactions). You will also need a Transaction Authorization Policy (TAP) that specifies who the signers are for transactions initiated by your API user, and this policy will need to permit contract creation as well as contract calls.
+> Your Fireblocks API user will need to have "Editor" permissions (i.e., the ability to propose transactions for signing, but not necessarily the ability to sign transactions). You will also need a Transaction Authorization Policy (TAP) that specifies who the signers are for transactions initiated by your API user, and this policy will need to permit contract creation as well as contract calls.
 
 > [!NOTE]
 > Before you approve any contract-call transactions, be sure you understand what the call does! When in doubt, use [Etherscan](https://etherscan.io/) to lookup the function selector, together with a [calldata decoder](https://openchain.xyz/tools/abi) ([alternative](https://calldata.swiss-knife.xyz/decoder)) to decode the call's arguments.

--- a/contracts/src/IRiscZeroVerifier.sol
+++ b/contracts/src/IRiscZeroVerifier.sol
@@ -42,7 +42,7 @@ struct ReceiptClaim {
     /// @notice The exit code for the execution.
     ExitCode exitCode;
     /// @notice A digest of the input to the guest.
-    /// @dev This field is currently unused and must be set to the zero digest.
+    /// @dev This field is currently unused and must be set to zero digest.
     bytes32 input;
     /// @notice Digest of the Output of the guest, including the journal
     /// and assumptions set during execution.

--- a/contracts/src/RiscZeroVerifierEmergencyStop.sol
+++ b/contracts/src/RiscZeroVerifierEmergencyStop.sol
@@ -34,7 +34,7 @@ contract RiscZeroVerifierEmergencyStop is IRiscZeroVerifier, Ownable2Step, Pausa
     }
 
     /// @notice Initiate an emergency stop of the verifier contract.
-    ///         Can only be used by the guardian address assigned as owner of this contract.
+    ///         Can only be used by the guardian address assigned as the owner of this contract.
     ///
     ///         When stopped, all calls to the verify and verifyIntegrity functions will revert.
     ///         Once stopped, this contract can never be restarted.

--- a/contracts/src/groth16/ControlID.sol
+++ b/contracts/src/groth16/ControlID.sol
@@ -21,6 +21,6 @@ pragma solidity ^0.8.9;
 
 library ControlID {
     bytes32 public constant CONTROL_ROOT = hex"a516a057c9fbf5629106300934d48e0e775d4230e41e503347cad96fcbde7e2e";
-    // NOTE: This has opposite byte order to the value in the risc0 repository.
+    // NOTE: This has the opposite byte order to the value in the risc0 repository.
     bytes32 public constant BN254_CONTROL_ID = hex"0eb6febcf06c5df079111be116f79bd8c7e85dc9448776ef9a59aaf2624ab551";
 }

--- a/contracts/src/groth16/RiscZeroGroth16Verifier.sol
+++ b/contracts/src/groth16/RiscZeroGroth16Verifier.sol
@@ -66,7 +66,7 @@ contract RiscZeroGroth16Verifier is IRiscZeroVerifier, Groth16Verifier {
     bytes16 public immutable CONTROL_ROOT_1;
     bytes32 public immutable BN254_CONTROL_ID;
 
-    /// @notice A short key attached to the seal to select the correct verifier implementation.
+    /// @notice A short key is attached to the seal to select the correct verifier implementation.
     /// @dev The selector is taken from the hash of the verifier parameters including the Groth16
     ///      verification key and the control IDs that commit to the RISC Zero circuits. If two
     ///      receipts have different selectors (i.e. different verifier parameters), then it can

--- a/steel/src/contract.rs
+++ b/steel/src/contract.rs
@@ -97,7 +97,7 @@ impl<'a, P, H> Contract<&'a mut HostEvmEnv<P, H>>
 where
     P: Provider,
 {
-    /// Constructor for preflighting calls to an Ethereum contract on the host.
+    /// Constructor for pre-flighting calls to an Ethereum contract on the host.
     ///
     /// Initializes the environment for calling functions on the Ethereum contract, fetching
     /// necessary data via the [Provider], and generating a storage proof for any accessed


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.