### PR TITLE
Fix publishing of `risc0-steel` (#151)

### DIFF
--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -87,11 +87,18 @@ impl<H: EvmBlockHeader> EvmInput<H> {
 
 // Keep everything in the Steel library private except the commitment.
 mod private {
-    alloy_sol_types::sol!("../contracts/src/steel/Steel.sol");
+    alloy_sol_types::sol! {
+        #![sol(all_derives)]
+        /// A Commitment struct representing a block number and its block hash.
+        struct Commitment {
+            uint256 blockNumber; // Block number at which the commitment was made.
+            bytes32 blockHash; // Hash of the block at the specified block number.
+        }
+    }
 }
 
 /// Solidity struct representing the committed block used for validation.
-pub use private::Steel::Commitment as SolCommitment;
+pub use private::Commitment as SolCommitment;
 
 /// Alias for readability, do not make public.
 pub(crate) type GuestEvmEnv<H> = EvmEnv<StateDb, H>;


### PR DESCRIPTION
This fixes #144 by copying the Solidity struct from `contracts` into the
`sol!` macro.
This removes all external dependencies, but we need to make sure that
these two places always match.

Cherry-pick of #151 to release-1.0
