### PR TITLE
Bump risc0-steel to v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 # Intra-workspace dependencies
 risc0-build-ethereum = { version = "1.0.0", default-features = false, path = "build" }
 risc0-ethereum-contracts = { version = "1.0.0", default-features = false, path = "contracts" }
-risc0-steel = { version = "0.11.0", default-features = false, path = "steel" }
+risc0-steel = { version = "0.11.1", default-features = false, path = "steel" }
 risc0-forge-ffi = { version = "1.0.0", default-features = false, path = "ffi" }
 
 # risc0 monorepo dependencies.

--- a/examples/erc20-counter/Cargo.lock
+++ b/examples/erc20-counter/Cargo.lock
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/examples/erc20-counter/methods/guest/Cargo.lock
+++ b/examples/erc20-counter/methods/guest/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/examples/erc20/Cargo.lock
+++ b/examples/erc20/Cargo.lock
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/examples/erc20/methods/guest/Cargo.lock
+++ b/examples/erc20/methods/guest/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-steel"
 description = "Query Ethereum state, or any other EVM-based blockchain state within the RISC Zero zkVM."
-version = "0.11.0"
+version = "0.11.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
As part of the release process for the patch version of Steel with https://github.com/risc0/risc0-ethereum/pull/158, this PR bumps the version of `risc0-steel` to `v0.11.1`.
