### PR TITLE
fix: Set min `alloy-rlp` version to 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ risc0-zkp = { git = "https://github.com/risc0/risc0", branch = "main", default-f
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false }
 
 alloy-primitives = { version = "0.7", features = ["serde", "rlp", "std"] }
-alloy-rlp = { version = "0.3.4", default-features = false }
-alloy-rlp-derive = { version = "0.3.4", default-features = false }
+alloy-rlp = { version = "0.3.7", default-features = false }
+alloy-rlp-derive = { version = "0.3.7", default-features = false }
 alloy-sol-types = { version = "0.7" }
 alloy-trie = { version = "0.4.0" }
 anyhow = { version = "1.0" }


### PR DESCRIPTION
Steel requires at least version `0.3.7`.