### PR TITLE
WEB3-80: Drop `no-default-features` when installing `cargo-risczero`

### DIFF
--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -28,7 +28,7 @@ runs:
           ref: ${{ inputs.ref }}
           lfs: true
       - name: install cargo-risczero
-        run: cargo install --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
+        run: cargo install --path risc0/cargo-risczero --features "${{ inputs.features }}"
         working-directory: tmp/risc0
         shell: bash
       - name: install r0vm


### PR DESCRIPTION
This should fix:

```
error[E0599]: no method named `env` found for struct `Arg` in the current scope
  --> risc0/cargo-risczero/src/commands/datasheet/mod.rs:41:38
   |
41 |     #[arg(long, value_name = "PATH", env = "RISC0_SERVER_PATH")]
   |                                      ^^^ method not found in `Arg`
```

Note that this behaviour started after merging https://github.com/risc0/risc0/pull/2196, that introduced the `env` usage in claps without adding the `env` feature
