### PR TITLE
WEB3-103: chore: use block hash for the provider

### DIFF
--- a/steel/src/block.rs
+++ b/steel/src/block.rs
@@ -102,7 +102,8 @@ pub mod host {
 
             // use the same provider as the database
             let provider = db.inner().provider();
-            let block_number = db.inner().block_number();
+            let block_hash = db.inner().block_hash();
+            assert_eq!(block_hash, env.header.seal(), "DB block mismatch");
 
             // retrieve EIP-1186 proofs for all accounts
             let mut proofs = Vec::new();
@@ -112,7 +113,7 @@ pub mod host {
                         *address,
                         storage_keys.iter().map(|v| StorageKey::from(*v)).collect(),
                     )
-                    .number(block_number)
+                    .hash(block_hash)
                     .await
                     .context("eth_getProof failed")?;
                 proofs.push(proof);
@@ -164,6 +165,7 @@ pub mod host {
             // retrieve ancestor block headers
             let mut ancestors = Vec::new();
             if let Some(&block_hash_min_number) = db.block_hash_numbers().iter().min() {
+                let block_number = env.header.number();
                 for number in (block_hash_min_number..block_number).rev() {
                     let rpc_block = provider
                         .get_block_by_number(number.into(), false)

--- a/steel/src/host/db/alloy.rs
+++ b/steel/src/host/db/alloy.rs
@@ -19,7 +19,7 @@ use alloy::{
     providers::Provider,
     transports::{Transport, TransportError},
 };
-use alloy_primitives::{Address, BlockNumber, B256, U256};
+use alloy_primitives::{Address, BlockHash, B256, U256};
 use revm::{
     primitives::{AccountInfo, Bytecode, HashMap, KECCAK_EMPTY},
     Database,
@@ -36,8 +36,8 @@ use tokio::runtime::Handle;
 pub struct AlloyDb<T: Transport + Clone, N: Network, P: Provider<T, N>> {
     /// Provider to fetch the data from.
     provider: P,
-    /// Block number on which the queries will be based on.
-    block_number: BlockNumber,
+    /// Hash of the block on which the queries will be based.
+    block_hash: BlockHash,
     /// Handle to the Tokio runtime.
     handle: Handle,
     /// Bytecode cache to allow querying bytecode by hash instead of address.
@@ -50,10 +50,10 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDb<T, N, P> {
     /// Create a new AlloyDb instance, with a [Provider] and a block.
     ///
     /// This will panic if called outside the context of a Tokio runtime.
-    pub fn new(provider: P, block_number: BlockNumber) -> Self {
+    pub fn new(provider: P, block_hash: BlockHash) -> Self {
         Self {
             provider,
-            block_number,
+            block_hash,
             handle: Handle::current(),
             contracts: HashMap::new(),
             phantom: PhantomData,
@@ -66,8 +66,8 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDb<T, N, P> {
     }
 
     /// Returns the block number used for the queries.
-    pub fn block_number(&self) -> BlockNumber {
-        self.block_number
+    pub fn block_hash(&self) -> BlockHash {
+        self.block_hash
     }
 }
 
@@ -79,9 +79,9 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> Database for AlloyDb<T
             let get_nonce = self
                 .provider
                 .get_transaction_count(address)
-                .number(self.block_number);
-            let get_balance = self.provider.get_balance(address).number(self.block_number);
-            let get_code = self.provider.get_code_at(address).number(self.block_number);
+                .hash(self.block_hash);
+            let get_balance = self.provider.get_balance(address).hash(self.block_hash);
+            let get_code = self.provider.get_code_at(address).hash(self.block_hash);
 
             tokio::join!(
                 get_nonce.into_future(),
@@ -132,7 +132,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> Database for AlloyDb<T
         let storage = self.handle.block_on(
             self.provider
                 .get_storage_at(address, index)
-                .number(self.block_number)
+                .hash(self.block_hash)
                 .into_future(),
         )?;
 

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -179,10 +179,11 @@ impl<P, H> EvmEnvBuilder<P, H> {
             .header
             .try_into()
             .map_err(|err| anyhow!("header invalid: {}", err))?;
-        log::info!("Environment initialized for block {}", header.number());
+        let sealed_header = header.seal_slow();
+        log::info!("Environment initialized for block {}", sealed_header.seal());
 
-        let db = TraceDb::new(AlloyDb::new(self.provider, header.number()));
+        let db = TraceDb::new(AlloyDb::new(self.provider, sealed_header.seal()));
 
-        Ok(EvmEnv::new(db, header.seal_slow()))
+        Ok(EvmEnv::new(db, sealed_header))
     }
 }


### PR DESCRIPTION
The `AlloyDb` is created for a specific block, and represents / queries the state with respect to that block.
This PR changes that reference from a block number to a block hash, which should prevent problems in weird situations like re-orgs or misconfigured RPCs.
This PR only changes the underlying representation, not the Steel API.