### PR TITLE
feat: configurable `eth_getProof` chunk size

### DIFF
--- a/steel/CHANGELOG.md
+++ b/steel/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Add support for creating a commitment to a beacon block root using `EvmEnv::into_beacon_input`, which can be verified using the [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) beacon roots contract.
 - Add the `EvmEnvBuilder` to simplify the creation of an `EvmEnv` on the host.
-- If an individual `eth_getProof` RPC call contains more than 1000 storage keys, it will be automatically split.
+- If an individual `eth_getProof` RPC call contains many storage keys, it will be automatically split. The chunk size can be configured using the `EvmEnvBuilder`.
 - Add `CallBuilder::prefetch_access_list` and `CallBuilder::call_with_prefetch` for that host that prefetch storage proofs and values to drastically reduce the number of RPC calls.
 
 ### 🚨 Breaking Changes

--- a/steel/src/host/db/alloy.rs
+++ b/steel/src/host/db/alloy.rs
@@ -53,10 +53,10 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDb<T, N, P> {
     /// Creates a new AlloyDb instance, with a [Provider] and a block.
     ///
     /// This will panic if called outside the context of a Tokio runtime.
-    pub fn new(provider: P, block_number: BlockNumber) -> Self {
+    pub fn new(provider: P, config: ProviderConfig, block_number: BlockNumber) -> Self {
         Self {
             provider,
-            provider_config: ProviderConfig::default(),
+            provider_config: config,
             block_number,
             handle: Handle::current(),
             contracts: HashMap::new(),

--- a/steel/src/host/db/alloy.rs
+++ b/steel/src/host/db/alloy.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashMap, future::IntoFuture, marker::PhantomData};
 
-use super::provider::ProviderDb;
+use super::provider::{ProviderConfig, ProviderDb};
 use alloy::{
     network::Network,
     providers::Provider,
@@ -37,6 +37,8 @@ use tokio::runtime::Handle;
 pub struct AlloyDb<T: Transport + Clone, N: Network, P: Provider<T, N>> {
     /// Provider to fetch the data from.
     provider: P,
+    /// Configuration of the provider.
+    provider_config: ProviderConfig,
     /// Block number on which the queries will be based on.
     block_number: BlockNumber,
     /// Handle to the Tokio runtime.
@@ -54,6 +56,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDb<T, N, P> {
     pub fn new(provider: P, block_number: BlockNumber) -> Self {
         Self {
             provider,
+            provider_config: ProviderConfig::default(),
             block_number,
             handle: Handle::current(),
             contracts: HashMap::new(),
@@ -63,6 +66,10 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDb<T, N, P> {
 }
 
 impl<T: Transport + Clone, N: Network, P: Provider<T, N>> ProviderDb<T, N, P> for AlloyDb<T, N, P> {
+    fn config(&self) -> &ProviderConfig {
+        &self.provider_config
+    }
+
     fn provider(&self) -> &P {
         &self.provider
     }

--- a/steel/src/host/db/mod.rs
+++ b/steel/src/host/db/mod.rs
@@ -21,4 +21,4 @@ mod provider;
 
 pub use alloy::AlloyDb;
 pub use proof::ProofDb;
-pub(crate) use provider::ProviderDb;
+pub(crate) use provider::{ProviderConfig, ProviderDb};

--- a/steel/src/host/db/proof.rs
+++ b/steel/src/host/db/proof.rs
@@ -137,7 +137,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> ProofDb<AlloyDb<T, N, 
     /// Returns the merkle proofs (sparse [MerkleTrie]) for the state and all storage queries
     /// recorded by the [Database].
     pub async fn state_proof(&mut self) -> Result<(MerkleTrie, Vec<MerkleTrie>)> {
-        let mut proofs = &mut self.proofs;
+        let proofs = &mut self.proofs;
 
         for (address, storage_keys) in &self.accounts {
             let account_proof = proofs.get(address);

--- a/steel/src/host/db/proof.rs
+++ b/steel/src/host/db/proof.rs
@@ -154,7 +154,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> ProofDb<AlloyDb<T, N, 
                     .get_eip1186_proof(*address, storage_keys)
                     .await
                     .context("eth_getProof failed")?;
-                add_proof(&mut proofs, proof).context("invalid eth_getProof response")?;
+                add_proof(proofs, proof).context("invalid eth_getProof response")?;
             }
         }
 

--- a/steel/src/host/db/provider.rs
+++ b/steel/src/host/db/provider.rs
@@ -21,6 +21,7 @@ use anyhow::{ensure, Result};
 use revm::Database;
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ProviderConfig {
     /// Max number of storage keys to request in a single `eth_getProof` call.
     pub eip1186_proof_chunk_size: usize,

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -31,7 +31,7 @@ use alloy::{
     },
 };
 use anyhow::{anyhow, Context, Result};
-use db::{AlloyDb, ProofDb};
+use db::{AlloyDb, ProofDb, ProviderConfig};
 use url::Url;
 
 pub mod db;
@@ -105,6 +105,7 @@ impl<H> EvmEnv<(), H> {
     pub fn builder() -> EvmEnvBuilder<NoProvider, H> {
         EvmEnvBuilder {
             provider: NoProvider,
+            provider_config: ProviderConfig::default(),
             block: BlockNumberOrTag::Latest,
             phantom: PhantomData,
         }
@@ -115,6 +116,7 @@ impl<H> EvmEnv<(), H> {
 #[derive(Clone, Debug)]
 pub struct EvmEnvBuilder<P, H> {
     provider: P,
+    provider_config: ProviderConfig,
     block: BlockNumberOrTag,
     phantom: PhantomData<H>,
 }
@@ -139,11 +141,11 @@ impl<H: EvmBlockHeader> EvmEnvBuilder<NoProvider, H> {
         H: EvmBlockHeader + TryFrom<RpcHeader>,
         <H as TryFrom<RpcHeader>>::Error: Display,
     {
-        let Self { block, phantom, .. } = self;
         EvmEnvBuilder {
             provider,
-            block,
-            phantom,
+            provider_config: self.provider_config,
+            block: self.block,
+            phantom: self.phantom,
         }
     }
 }
@@ -157,6 +159,13 @@ impl<P, H> EvmEnvBuilder<P, H> {
     /// Sets the block number (or tag - "latest", "earliest", "pending").
     pub fn block_number_or_tag(mut self, block: BlockNumberOrTag) -> Self {
         self.block = block;
+        self
+    }
+
+    /// Sets the max number of storage keys to request in a single `eth_getProof` call.
+    pub fn eip1186_proof_chunk_size(mut self, chunk_size: usize) -> Self {
+        assert_ne!(chunk_size, 0, "chunk size must be non-zero");
+        self.provider_config.eip1186_proof_chunk_size = chunk_size;
         self
     }
 
@@ -181,7 +190,11 @@ impl<P, H> EvmEnvBuilder<P, H> {
             .map_err(|err| anyhow!("header invalid: {}", err))?;
         log::info!("Environment initialized for block {}", header.number());
 
-        let db = ProofDb::new(AlloyDb::new(self.provider, header.number()));
+        let db = ProofDb::new(AlloyDb::new(
+            self.provider,
+            self.provider_config,
+            header.number(),
+        ));
 
         Ok(EvmEnv::new(db, header.seal_slow()))
     }

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -163,6 +163,8 @@ impl<P, H> EvmEnvBuilder<P, H> {
     }
 
     /// Sets the max number of storage keys to request in a single `eth_getProof` call.
+    ///
+    /// The optimal number depends on the RPC node and its configuration, but the default is 1000.
     pub fn eip1186_proof_chunk_size(mut self, chunk_size: usize) -> Self {
         assert_ne!(chunk_size, 0, "chunk size must be non-zero");
         self.provider_config.eip1186_proof_chunk_size = chunk_size;


### PR DESCRIPTION
Makes the EIP-1186 proof request chunk size configurable in the builder.

closes WEB3-56