### PR TITLE
WEB3-146: Replace map types with `alloy_primitives::map`

### DIFF
--- a/steel/src/block.rs
+++ b/steel/src/block.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use crate::{state::StateDb, EvmBlockHeader, EvmEnv, GuestEvmEnv, MerkleTrie};
 use ::serde::{Deserialize, Serialize};
-use alloy_primitives::Bytes;
+use alloy_primitives::{map::HashMap, Bytes};
 
 /// Input committing to the corresponding execution block hash.
 #[derive(Clone, Serialize, Deserialize)]
@@ -39,7 +37,8 @@ impl<H: EvmBlockHeader> BlockInput<H> {
         let header = self.header.seal_slow();
 
         // validate that ancestor headers form a valid chain
-        let mut block_hashes = HashMap::with_capacity(self.ancestors.len() + 1);
+        let mut block_hashes =
+            HashMap::with_capacity_and_hasher(self.ancestors.len() + 1, Default::default());
         block_hashes.insert(header.number(), header.seal());
 
         let mut previous_header = header.inner();

--- a/steel/src/block.rs
+++ b/steel/src/block.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use crate::{state::StateDb, EvmBlockHeader, EvmEnv, GuestEvmEnv, MerkleTrie};
 use ::serde::{Deserialize, Serialize};
 use alloy_primitives::Bytes;
-use revm::primitives::HashMap;
 
 /// Input committing to the corresponding execution block hash.
 #[derive(Clone, Serialize, Deserialize)]

--- a/steel/src/host/db/alloy.rs
+++ b/steel/src/host/db/alloy.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, future::IntoFuture, marker::PhantomData};
+use std::{future::IntoFuture, marker::PhantomData};
 
 use super::provider::{ProviderConfig, ProviderDb};
 use alloy::{
@@ -20,7 +20,7 @@ use alloy::{
     providers::Provider,
     transports::{Transport, TransportError},
 };
-use alloy_primitives::{Address, BlockHash, B256, U256};
+use alloy_primitives::{map::B256HashMap, Address, BlockHash, B256, U256};
 use revm::{
     primitives::{AccountInfo, Bytecode},
     Database,
@@ -44,7 +44,7 @@ pub struct AlloyDb<T: Transport + Clone, N: Network, P: Provider<T, N>> {
     /// Handle to the Tokio runtime.
     handle: Handle,
     /// Bytecode cache to allow querying bytecode by hash instead of address.
-    contracts: HashMap<B256, Bytecode>,
+    contracts: B256HashMap<Bytecode>,
 
     phantom: PhantomData<fn() -> (T, N)>,
 }
@@ -59,7 +59,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDb<T, N, P> {
             provider_config: config,
             block_hash,
             handle: Handle::current(),
-            contracts: HashMap::new(),
+            contracts: Default::default(),
             phantom: PhantomData,
         }
     }

--- a/steel/src/mpt.rs
+++ b/steel/src/mpt.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, fmt::Debug};
+use std::fmt::Debug;
 
-use alloy_primitives::{b256, keccak256, B256};
+use alloy_primitives::{b256, keccak256, map::B256HashMap, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, PayloadView, EMPTY_STRING_CODE};
 use nybbles::Nibbles;
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,7 @@ impl MerkleTrie {
     pub fn from_rlp_nodes<T: AsRef<[u8]>>(
         nodes: impl IntoIterator<Item = T>,
     ) -> alloy_rlp::Result<Self> {
-        let mut nodes_by_hash = HashMap::new();
+        let mut nodes_by_hash = B256HashMap::default();
         let mut root_node_opt = None;
 
         for rlp in nodes {
@@ -332,7 +332,7 @@ fn parse_node(rlp: impl AsRef<[u8]>) -> alloy_rlp::Result<(Option<B256>, Node)> 
     Ok(((rlp.len() >= 32).then(|| keccak256(rlp)), node))
 }
 
-fn resolve_trie(root: Node, nodes_by_hash: &HashMap<B256, Node>) -> Node {
+fn resolve_trie(root: Node, nodes_by_hash: &B256HashMap<Node>) -> Node {
     match root {
         Node::Null | Node::Leaf(..) => root,
         Node::Extension(prefix, child) => {

--- a/steel/src/state.rs
+++ b/steel/src/state.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{convert::Infallible, fmt::Debug, rc::Rc};
+use std::{collections::HashMap, convert::Infallible, fmt::Debug, rc::Rc};
 
 use crate::mpt::{MerkleTrie, EMPTY_ROOT_HASH};
 use alloy_primitives::{keccak256, Address, Bytes, TxNumber, B256, U256};
 use alloy_rlp_derive::{RlpDecodable, RlpEncodable};
 use revm::{
-    primitives::{AccountInfo, Bytecode, HashMap, KECCAK_EMPTY},
+    primitives::{AccountInfo, Bytecode, KECCAK_EMPTY},
     Database,
 };
 

--- a/steel/src/state.rs
+++ b/steel/src/state.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, convert::Infallible, fmt::Debug, rc::Rc};
+use std::{convert::Infallible, fmt::Debug, rc::Rc};
 
 use crate::mpt::{MerkleTrie, EMPTY_ROOT_HASH};
-use alloy_primitives::{keccak256, Address, Bytes, TxNumber, B256, U256};
+use alloy_primitives::{
+    keccak256,
+    map::{AddressHashMap, B256HashMap, HashMap},
+    Address, Bytes, TxNumber, B256, U256,
+};
 use alloy_rlp_derive::{RlpDecodable, RlpEncodable};
 use revm::{
     primitives::{AccountInfo, Bytecode, KECCAK_EMPTY},
@@ -35,9 +39,9 @@ pub struct StateDb {
     state_trie: MerkleTrie,
     /// Storage MPTs to their root hash.
     /// [Rc] is used fore MPT deduplication.
-    storage_tries: HashMap<B256, Rc<MerkleTrie>>,
+    storage_tries: B256HashMap<Rc<MerkleTrie>>,
     /// Contracts by their hash.
-    contracts: HashMap<B256, Bytes>,
+    contracts: B256HashMap<Bytes>,
     /// Block hashes by their number.
     block_hashes: HashMap<u64, B256>,
 }
@@ -103,7 +107,7 @@ impl StateDb {
 /// account.
 pub struct WrapStateDb<'a> {
     inner: &'a StateDb,
-    account_storage: HashMap<Address, Option<Rc<MerkleTrie>>>,
+    account_storage: AddressHashMap<Option<Rc<MerkleTrie>>>,
 }
 
 impl<'a> WrapStateDb<'a> {
@@ -111,7 +115,7 @@ impl<'a> WrapStateDb<'a> {
     pub fn new(inner: &'a StateDb) -> Self {
         Self {
             inner,
-            account_storage: HashMap::new(),
+            account_storage: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This fixes the current compilation errors.

Previously, we used to use `revm::primitives::HashMap` to have the same hash in Steel and `revm`. However, with the latest (minor) revm version, this has been switched to using `alloy_primitves::map::HashMap`. Thus, in this PR we also replace all `{Hash,BTree}{Map,Set}` with their more performant and specific equivalent in `alloy_primitives::map`.

### Additional context
- https://github.com/alloy-rs/alloy/issues/1365