### PR TITLE
WEB3-159: Use `decode_exact` for MPT leaves

### DIFF
--- a/steel/CHANGELOG.md
+++ b/steel/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### 🛠 Fixes
 
 - Return specific error, when no `Contract::preflight` was called.
+- Use `decode_exact` when RLP-decoding the MPT leaves.
 
 ### 🚨 Breaking Changes
 

--- a/steel/src/mpt.rs
+++ b/steel/src/mpt.rs
@@ -43,7 +43,7 @@ impl MerkleTrie {
     #[inline]
     pub fn get_rlp<T: Decodable>(&self, key: impl AsRef<[u8]>) -> alloy_rlp::Result<Option<T>> {
         match self.get(key) {
-            Some(mut bytes) => Ok(Some(T::decode(&mut bytes)?)),
+            Some(bytes) => Ok(Some(alloy_rlp::decode_exact(bytes)?)),
             None => Ok(None),
         }
     }


### PR DESCRIPTION
Assure that there are never trailing bytes stored in MPT leaves. This will never be the case for valid Ethereum MPTs