### PR TITLE
WEB3-151: Use builder also for beacon input

### DIFF
--- a/examples/erc20-counter/apps/src/bin/publisher.rs
+++ b/examples/erc20-counter/apps/src/bin/publisher.rs
@@ -126,6 +126,7 @@ async fn main() -> Result<()> {
     // There are two options: Use EIP-4788 for verification by providing a Beacon API endpoint,
     // or use the regular `blockhash' opcode.
     let evm_input = if let Some(beacon_api_url) = args.beacon_api_url {
+        #[allow(deprecated)]
         env.into_beacon_input(beacon_api_url).await?
     } else {
         env.into_input().await?

--- a/examples/erc20/host/src/main.rs
+++ b/examples/erc20/host/src/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use alloy_primitives::{address, Address};
-use alloy_sol_types::{sol, SolCall};
+use alloy_sol_types::{sol, SolCall, SolType};
 use anyhow::{Context, Result};
 use clap::Parser;
 use erc20_methods::ERC20_GUEST_ELF;

--- a/examples/erc20/host/src/main.rs
+++ b/examples/erc20/host/src/main.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use erc20_methods::ERC20_GUEST_ELF;
 use risc0_steel::{
     ethereum::{EthEvmEnv, ETH_SEPOLIA_CHAIN_SPEC},
-    Contract,
+    Commitment, Contract,
 };
 use risc0_zkvm::{default_executor, ExecutorEnv};
 use tracing_subscriber::EnvFilter;
@@ -77,8 +77,6 @@ async fn main() -> Result<()> {
         CONTRACT,
         returns._0
     );
-    // Get the commitment to verify execution later.
-    let commitment = env.commitment().clone();
 
     // Finally, construct the input from the environment.
     let input = env.into_input().await?;
@@ -95,9 +93,10 @@ async fn main() -> Result<()> {
             .context("failed to run executor")?
     };
 
-    // The commitment in the journal should match.
-    let bytes = session_info.journal.as_ref();
-    assert!(bytes.starts_with(&commitment.abi_encode()));
+    // The journal should be the ABI encoded commitment.
+    let commitment = Commitment::abi_decode(session_info.journal.as_ref(), true)
+        .context("failed to decode journal")?;
+    println!("{:?}", commitment);
 
     Ok(())
 }

--- a/examples/token-stats/host/src/main.rs
+++ b/examples/token-stats/host/src/main.rs
@@ -73,8 +73,6 @@ async fn main() -> Result<()> {
         CONTRACT,
         rate
     );
-    // Get the commitment to verify execution later.
-    let commitment = env.commitment().clone();
 
     // Finally, construct the input from the environment.
     let input = env.into_input().await?;
@@ -91,9 +89,10 @@ async fn main() -> Result<()> {
             .context("failed to run executor")?
     };
 
+    // The journal should be the ABI encoded commitment.
     let apr_commit = APRCommitment::abi_decode(&session_info.journal.bytes, true)
         .context("failed to decode journal")?;
-    assert_eq!(apr_commit.commitment, commitment);
+    println!("{:?}", apr_commit.commitment);
 
     // Calculation is handling `/ 10^18 * 100` to match precision for a percentage.
     let apr = apr_commit.annualSupplyRate as f64 / 10f64.powi(16);

--- a/steel/src/block.rs
+++ b/steel/src/block.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{state::StateDb, EvmBlockHeader, EvmEnv, GuestEvmEnv, MerkleTrie};
+use crate::{state::StateDb, Commitment, EvmBlockHeader, EvmEnv, GuestEvmEnv, MerkleTrie};
 use ::serde::{Deserialize, Serialize};
 use alloy_primitives::{map::HashMap, Bytes};
 
@@ -61,8 +61,9 @@ impl<H: EvmBlockHeader> BlockInput<H> {
             self.contracts,
             block_hashes,
         );
+        let commit = Commitment::from_block_header(&header);
 
-        EvmEnv::new(db, header)
+        EvmEnv::new(db, header, commit)
     }
 }
 
@@ -72,20 +73,20 @@ pub mod host {
 
     use super::BlockInput;
     use crate::{
-        host::{
-            db::{AlloyDb, ProviderDb},
-            HostEvmEnv,
-        },
+        host::db::{AlloyDb, ProofDb, ProviderDb},
         EvmBlockHeader,
     };
     use alloy::{network::Network, providers::Provider, transports::Transport};
+    use alloy_primitives::Sealed;
     use anyhow::{anyhow, ensure};
-    use log::{debug, info};
+    use log::debug;
 
     impl<H: EvmBlockHeader> BlockInput<H> {
-        /// Derives the verifiable input from a [HostEvmEnv].
-        pub(crate) async fn from_env<T, N, P>(
-            env: HostEvmEnv<AlloyDb<T, N, P>, H>,
+        /// Creates the `BlockInput` containing the necessary EVM state that can be verified against
+        /// the block hash.
+        pub(crate) async fn from_proof_db<T, N, P>(
+            mut db: ProofDb<AlloyDb<T, N, P>>,
+            header: Sealed<H>,
         ) -> anyhow::Result<Self>
         where
             T: Transport + Clone,
@@ -94,17 +95,11 @@ pub mod host {
             H: EvmBlockHeader + TryFrom<<N as Network>::HeaderResponse>,
             <H as TryFrom<<N as Network>::HeaderResponse>>::Error: Display,
         {
-            // safe unwrap: env is never returned without a DB
-            let mut db = env.db.unwrap();
-            assert_eq!(
-                db.inner().block_hash(),
-                env.header.seal(),
-                "DB block mismatch"
-            );
+            assert_eq!(db.inner().block_hash(), header.seal(), "DB block mismatch");
 
             let (state_trie, storage_tries) = db.state_proof().await?;
             ensure!(
-                env.header.state_root() == &state_trie.hash_slow(),
+                header.state_root() == &state_trie.hash_slow(),
                 "accountProof root does not match header's stateRoot"
             );
 
@@ -113,7 +108,7 @@ pub mod host {
 
             // retrieve ancestor block headers
             let mut ancestors = Vec::new();
-            for rlp_header in db.ancestor_proof(env.header.number()).await? {
+            for rlp_header in db.ancestor_proof(header.number()).await? {
                 let header: H = rlp_header
                     .try_into()
                     .map_err(|err| anyhow!("header invalid: {}", err))?;
@@ -129,14 +124,8 @@ pub mod host {
             debug!("contracts: {}", contracts.len());
             debug!("ancestor blocks: {}", ancestors.len());
 
-            info!(
-                "Commitment to block hash {} at {}",
-                env.header.seal(),
-                env.header.number()
-            );
-
             let input = BlockInput {
-                header: env.header.into_inner(),
+                header: header.into_inner(),
                 state_trie,
                 storage_tries,
                 contracts,

--- a/steel/src/block.rs
+++ b/steel/src/block.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{state::StateDb, Commitment, EvmBlockHeader, EvmEnv, GuestEvmEnv, MerkleTrie};
+use crate::config::ChainSpec;
+use crate::{
+    state::StateDb, Commitment, CommitmentVersion, EvmBlockHeader, EvmEnv, GuestEvmEnv, MerkleTrie,
+};
 use ::serde::{Deserialize, Serialize};
 use alloy_primitives::{map::HashMap, Bytes};
 
@@ -61,7 +64,12 @@ impl<H: EvmBlockHeader> BlockInput<H> {
             self.contracts,
             block_hashes,
         );
-        let commit = Commitment::from_block_header(&header);
+        let commit = Commitment::new(
+            CommitmentVersion::Block as u16,
+            header.number(),
+            header.seal(),
+            ChainSpec::DEFAULT_DIGEST,
+        );
 
         EvmEnv::new(db, header, commit)
     }

--- a/steel/src/contract.rs
+++ b/steel/src/contract.rs
@@ -295,7 +295,7 @@ where
     ///
     /// A convenience wrapper for [CallBuilder::try_call], panicking if the call fails. Useful when
     /// success is expected.
-    pub fn call(self) -> C::Return {
+    pub fn call(self) -> S::Return {
         self.try_call().unwrap()
     }
 }

--- a/steel/src/contract.rs
+++ b/steel/src/contract.rs
@@ -84,7 +84,7 @@ impl<'a, H> Contract<&'a GuestEvmEnv<H>> {
     }
 
     /// Initializes a call builder to execute a call on the contract.
-    pub fn call_builder<C: SolCall>(&self, call: &C) -> CallBuilder<C, &GuestEvmEnv<H>> {
+    pub fn call_builder<S: SolCall>(&self, call: &S) -> CallBuilder<S, &GuestEvmEnv<H>> {
         CallBuilder::new(self.env, self.address, call)
     }
 }
@@ -94,19 +94,19 @@ impl<'a, H> Contract<&'a GuestEvmEnv<H>> {
 /// Once configured, call with [CallBuilder::call].
 #[derive(Debug, Clone)]
 #[must_use]
-pub struct CallBuilder<C, E> {
-    tx: CallTxData<C>,
+pub struct CallBuilder<S, E> {
+    tx: CallTxData<S>,
     env: E,
 }
 
-impl<C, E> CallBuilder<C, E> {
+impl<S, E> CallBuilder<S, E> {
     /// The default gas limit for function calls.
     const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
 
     /// Creates a new builder for the given contract call.
-    fn new(env: E, address: Address, call: &C) -> Self
+    fn new(env: E, address: Address, call: &S) -> Self
     where
-        C: SolCall,
+        S: SolCall,
     {
         let tx = CallTxData {
             caller: address, // by default the contract calls itself
@@ -160,7 +160,7 @@ mod host {
     };
     use anyhow::{anyhow, Context, Result};
 
-    impl<'a, D: Database, H> Contract<&'a mut HostEvmEnv<D, H>> {
+    impl<'a, D: Database, H, C> Contract<&'a mut HostEvmEnv<D, H, C>> {
         /// Constructor for preflighting calls to an Ethereum contract on the host.
         ///
         /// Initializes the environment for calling functions on the Ethereum contract, fetching
@@ -169,26 +169,26 @@ mod host {
         ///
         /// [EvmEnv::into_input]: crate::EvmEnv::into_input
         /// [EvmEnv]: crate::EvmEnv
-        pub fn preflight(address: Address, env: &'a mut HostEvmEnv<D, H>) -> Self {
+        pub fn preflight(address: Address, env: &'a mut HostEvmEnv<D, H, C>) -> Self {
             Self { address, env }
         }
 
         /// Initializes a call builder to execute a call on the contract.
-        pub fn call_builder<C: SolCall>(
+        pub fn call_builder<S: SolCall>(
             &mut self,
-            call: &C,
-        ) -> CallBuilder<C, &mut HostEvmEnv<D, H>> {
+            call: &S,
+        ) -> CallBuilder<S, &mut HostEvmEnv<D, H, C>> {
             CallBuilder::new(self.env, self.address, call)
         }
     }
 
-    impl<'a, C, T, N, P, H> CallBuilder<C, &'a mut HostEvmEnv<AlloyDb<T, N, P>, H>>
+    impl<'a, S, T, N, P, H, C> CallBuilder<S, &'a mut HostEvmEnv<AlloyDb<T, N, P>, H, C>>
     where
         T: Transport + Clone,
         N: Network,
         P: Provider<T, N> + Send + 'static,
-        C: SolCall + Send + 'static,
-        <C as SolCall>::Return: Send,
+        S: SolCall + Send + 'static,
+        <S as SolCall>::Return: Send,
         H: EvmBlockHeader + Clone + Send + 'static,
     {
         /// Fetches all the EIP-1186 storage proofs from the `access_list`. This can help to
@@ -208,10 +208,10 @@ mod host {
         /// This uses [tokio::task::spawn_blocking] to run the blocking revm execution.
         ///
         /// [EvmEnv]: crate::EvmEnv
-        pub async fn call(self) -> Result<C::Return> {
+        pub async fn call(self) -> Result<S::Return> {
             log::info!(
                 "Executing preflight calling '{}' on {}",
-                C::SIGNATURE,
+                S::SIGNATURE,
                 self.tx.to
             );
 
@@ -233,7 +233,7 @@ mod host {
             // restore the DB before handling errors, so that we never return an env without a DB
             self.env.db = Some(db);
 
-            result.map_err(|err| anyhow!("call '{}' failed: {}", C::SIGNATURE, err))
+            result.map_err(|err| anyhow!("call '{}' failed: {}", S::SIGNATURE, err))
         }
 
         /// Automatically prefetches the access list before executing the call using an [EvmEnv]
@@ -244,7 +244,7 @@ mod host {
         /// [CallBuilder::call]. See the corresponding methods for more information.
         ///
         /// [EvmEnv]: crate::EvmEnv
-        pub async fn call_with_prefetch(self) -> Result<C::Return> {
+        pub async fn call_with_prefetch(self) -> Result<S::Return> {
             let access_list = {
                 let tx = <N as Network>::TransactionRequest::default()
                     .with_from(self.tx.caller)
@@ -273,16 +273,16 @@ mod host {
     }
 }
 
-impl<'a, C, H> CallBuilder<C, &'a GuestEvmEnv<H>>
+impl<'a, S, H> CallBuilder<S, &'a GuestEvmEnv<H>>
 where
-    C: SolCall,
+    S: SolCall,
     H: EvmBlockHeader,
 {
     /// Executes the call and returns an error if the call fails.
     ///
     /// In general, it's recommended to use [CallBuilder::call] unless explicit error handling is
     /// required.
-    pub fn try_call(self) -> Result<C::Return, String> {
+    pub fn try_call(self) -> Result<S::Return, String> {
         let mut evm = new_evm::<_, H>(
             WrapStateDb::new(self.env.db()),
             self.env.cfg_env.clone(),
@@ -302,25 +302,25 @@ where
 
 /// Transaction data to be used with [CallBuilder] for an execution.
 #[derive(Debug, Clone)]
-struct CallTxData<C> {
+struct CallTxData<S> {
     caller: Address,
     gas_limit: u64,
     gas_price: U256,
     to: Address,
     value: U256,
     data: Vec<u8>,
-    phantom: PhantomData<C>,
+    phantom: PhantomData<S>,
 }
 
-impl<C: SolCall> CallTxData<C> {
+impl<S: SolCall> CallTxData<S> {
     /// Compile-time assertion that the call C has a return value.
     const RETURNS: () = assert!(
-        mem::size_of::<C::Return>() > 0,
+        mem::size_of::<S::Return>() > 0,
         "Function call must have a return value"
     );
 
     /// Executes the call in the provided [Evm].
-    fn transact<EXT, DB>(self, evm: &mut Evm<'_, EXT, DB>) -> Result<C::Return, String>
+    fn transact<EXT, DB>(self, evm: &mut Evm<'_, EXT, DB>) -> Result<S::Return, String>
     where
         DB: Database,
         <DB as Database>::Error: std::error::Error + Send + Sync + 'static,
@@ -351,10 +351,10 @@ impl<C: SolCall> CallTxData<C> {
             ExecutionResult::Revert { output, .. } => Err(format!("reverted: {}", output)),
             ExecutionResult::Halt { reason, .. } => Err(format!("halted: {:?}", reason)),
         }?;
-        let returns = C::abi_decode_returns(&output.into_data(), true).map_err(|err| {
+        let returns = S::abi_decode_returns(&output.into_data(), true).map_err(|err| {
             format!(
                 "return type invalid; expected '{}': {}",
-                <C::ReturnTuple<'_> as SolType>::SOL_NAME,
+                <S::ReturnTuple<'_> as SolType>::SOL_NAME,
                 err
             )
         })?;

--- a/steel/src/ethereum.rs
+++ b/steel/src/ethereum.rs
@@ -55,7 +55,7 @@ pub static ETH_MAINNET_CHAIN_SPEC: Lazy<ChainSpec> = Lazy::new(|| ChainSpec {
 });
 
 /// [EvmEnv] for Ethereum.
-pub type EthEvmEnv<D> = EvmEnv<D, EthBlockHeader>;
+pub type EthEvmEnv<D, C> = EvmEnv<D, EthBlockHeader, C>;
 
 /// [EvmInput] for Ethereum.
 pub type EthEvmInput = EvmInput<EthBlockHeader>;

--- a/steel/src/host/builder.rs
+++ b/steel/src/host/builder.rs
@@ -173,7 +173,7 @@ impl<P, H, B> EvmEnvBuilder<P, H, B> {
 
 impl<P, H> EvmEnvBuilder<P, H, ()> {
     /// Builds and returns an [EvmEnv] with the configured settings that commits to a block hash.
-    pub async fn build<T, N>(self) -> Result<HostEvmEnv<AlloyDb<T, N, P>, H, HostCommit<()>>>
+    pub async fn build<T, N>(self) -> Result<HostEvmEnv<AlloyDb<T, N, P>, H, ()>>
     where
         T: Transport + Clone,
         N: Network,
@@ -204,9 +204,7 @@ impl<P, H> EvmEnvBuilder<P, H, ()> {
 
 impl<P> EvmEnvBuilder<P, EthBlockHeader, Url> {
     /// Builds and returns an [EvmEnv] with the configured settings that commits to a beacon root.
-    pub async fn build<T>(
-        self,
-    ) -> Result<EthHostEvmEnv<AlloyDb<T, Ethereum, P>, HostCommit<BeaconCommit>>>
+    pub async fn build<T>(self) -> Result<EthHostEvmEnv<AlloyDb<T, Ethereum, P>, BeaconCommit>>
     where
         T: Transport + Clone,
         P: Provider<T, Ethereum>,

--- a/steel/src/host/builder.rs
+++ b/steel/src/host/builder.rs
@@ -1,0 +1,272 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    beacon::BeaconCommit,
+    ethereum::EthBlockHeader,
+    host::{
+        db::{AlloyDb, ProofDb, ProviderConfig},
+        BlockNumberOrTag, EthHostEvmEnv, HostEvmEnv,
+    },
+    EvmBlockHeader, EvmEnv,
+};
+use alloy::{
+    network::{BlockResponse, Ethereum, Network},
+    providers::{Provider, ProviderBuilder, ReqwestProvider},
+    transports::Transport,
+};
+use alloy_primitives::Sealable;
+use anyhow::{anyhow, Context, Result};
+use std::{fmt::Display, marker::PhantomData};
+use url::Url;
+
+impl<H> EvmEnv<(), H, ()> {
+    /// Creates a builder for building an environment.
+    ///
+    /// Create an Ethereum environment bast on the latest block:
+    /// ```rust,no_run
+    /// # use risc0_steel::ethereum::EthEvmEnv;
+    /// # use url::Url;
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// # let url = Url::parse("https://ethereum-rpc.publicnode.com")?;
+    /// let env = EthEvmEnv::builder().rpc(url).build().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn builder() -> EvmEnvBuilder<(), H, ()> {
+        EvmEnvBuilder {
+            provider: (),
+            provider_config: ProviderConfig::default(),
+            block: BlockNumberOrTag::Latest,
+            beacon_config: (),
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// Builder for constructing an [EvmEnv] instance on the host.
+///
+/// The [EvmEnvBuilder] is used to configure and create an [EvmEnv], which is the environment in
+/// which the Ethereum Virtual Machine (EVM) operates. This builder provides flexibility in setting
+/// up the EVM environment by allowing configuration of RPC endpoints, block numbers, and other
+/// parameters.
+///
+/// # Usage
+/// The builder can be created using [EvmEnv::builder()]. Various configurations can be chained to
+/// customize the environment before calling the `build` function to create the final [EvmEnv].
+///
+/// # Type Parameters
+/// - `P`: The type of the RPC provider that interacts with the blockchain.
+/// - `H`: The type of the block header.
+/// - `B`: The type of the configuration to access the Beacon API.
+#[derive(Clone, Debug)]
+pub struct EvmEnvBuilder<P, H, B> {
+    provider: P,
+    provider_config: ProviderConfig,
+    block: BlockNumberOrTag,
+    beacon_config: B,
+    phantom: PhantomData<H>,
+}
+
+impl EvmEnvBuilder<(), EthBlockHeader, ()> {
+    /// Sets the Ethereum HTTP RPC endpoint that will be used by the [EvmEnv].
+    pub fn rpc(self, url: Url) -> EvmEnvBuilder<ReqwestProvider<Ethereum>, EthBlockHeader, ()> {
+        self.provider(ProviderBuilder::new().on_http(url))
+    }
+}
+
+impl<H: EvmBlockHeader> EvmEnvBuilder<(), H, ()> {
+    /// Sets a custom [Provider] that will be used by the [EvmEnv].
+    pub fn provider<T, N, P>(self, provider: P) -> EvmEnvBuilder<P, H, ()>
+    where
+        T: Transport + Clone,
+        N: Network,
+        P: Provider<T, N>,
+        H: EvmBlockHeader + TryFrom<<N as Network>::HeaderResponse>,
+        <H as TryFrom<<N as Network>::HeaderResponse>>::Error: Display,
+    {
+        EvmEnvBuilder {
+            provider,
+            provider_config: self.provider_config,
+            block: self.block,
+            beacon_config: self.beacon_config,
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<P> EvmEnvBuilder<P, EthBlockHeader, ()> {
+    /// Sets the Beacon API URL for retrieving Ethereum Beacon block root commitments.
+    ///
+    /// This function configures the [EvmEnv] to interact with an Ethereum Beacon chain.
+    /// It assumes the use of the [mainnet](https://github.com/ethereum/consensus-specs/blob/v1.4.0/configs/mainnet.yaml) preset for consensus specs.
+    pub fn beacon_api(self, url: Url) -> EvmEnvBuilder<P, EthBlockHeader, Url> {
+        EvmEnvBuilder {
+            provider: self.provider,
+            provider_config: self.provider_config,
+            block: self.block,
+            beacon_config: url,
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<P, H, B> EvmEnvBuilder<P, H, B> {
+    /// Sets the block number to be used for the EVM execution.
+    pub fn block_number(self, number: u64) -> Self {
+        self.block_number_or_tag(BlockNumberOrTag::Number(number))
+    }
+
+    /// Sets the block number or block tag ("latest", "earliest", "pending") to be used for the EVM
+    /// execution.
+    pub fn block_number_or_tag(mut self, block: BlockNumberOrTag) -> Self {
+        self.block = block;
+        self
+    }
+
+    /// Sets the chunk size for `eth_getProof` calls (EIP-1186).
+    ///
+    /// This configures the number of storage keys to request in a single call.
+    /// The default is 1000, but this can be adjusted based on the RPC node configuration.
+    pub fn eip1186_proof_chunk_size(mut self, chunk_size: usize) -> Self {
+        assert_ne!(chunk_size, 0, "chunk size must be non-zero");
+        self.provider_config.eip1186_proof_chunk_size = chunk_size;
+        self
+    }
+
+    /// Retrieves the block header based on the current builder configuration.
+    async fn get_header<T, N>(&self) -> Result<H>
+    where
+        T: Transport + Clone,
+        N: Network,
+        P: Provider<T, N>,
+        H: EvmBlockHeader + TryFrom<<N as Network>::HeaderResponse>,
+        <H as TryFrom<<N as Network>::HeaderResponse>>::Error: Display,
+    {
+        let number = self.block.into_rpc_type(&self.provider).await?;
+        let rpc_block = self
+            .provider
+            .get_block_by_number(number, false)
+            .await
+            .context("eth_getBlockByNumber failed")?
+            .with_context(|| format!("block {} not found", number))?;
+        let header = rpc_block.header().clone();
+        header
+            .try_into()
+            .map_err(|err| anyhow!("header invalid: {}", err))
+    }
+}
+
+impl<P, H> EvmEnvBuilder<P, H, ()> {
+    /// Builds and returns an [EvmEnv] with the configured settings that commits to a block hash.
+    pub async fn build<T, N>(self) -> Result<HostEvmEnv<AlloyDb<T, N, P>, H, ()>>
+    where
+        T: Transport + Clone,
+        N: Network,
+        P: Provider<T, N>,
+        H: EvmBlockHeader + TryFrom<<N as Network>::HeaderResponse>,
+        <H as TryFrom<<N as Network>::HeaderResponse>>::Error: Display,
+    {
+        let header = self.get_header().await?.seal_slow();
+        log::info!(
+            "Environment initialized with block {} ({})",
+            header.number(),
+            header.seal()
+        );
+
+        let db = ProofDb::new(AlloyDb::new(
+            self.provider,
+            self.provider_config,
+            header.seal(),
+        ));
+
+        Ok(EvmEnv::new(db, header, ()))
+    }
+}
+
+impl<P> EvmEnvBuilder<P, EthBlockHeader, Url> {
+    /// Builds and returns an [EvmEnv] with the configured settings that commits to a beacon root.
+    pub async fn build<T>(self) -> Result<EthHostEvmEnv<AlloyDb<T, Ethereum, P>, BeaconCommit>>
+    where
+        T: Transport + Clone,
+        P: Provider<T, Ethereum>,
+    {
+        let header = self.get_header().await?.seal_slow();
+        log::info!(
+            "Environment initialized with block {} ({})",
+            header.number(),
+            header.seal()
+        );
+
+        let commitment =
+            BeaconCommit::from_header(&header, &self.provider, self.beacon_config).await?;
+        let db = ProofDb::new(AlloyDb::new(
+            self.provider,
+            self.provider_config,
+            header.seal(),
+        ));
+
+        Ok(EvmEnv::new(db, header, commitment))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ethereum::EthEvmEnv, BlockHeaderCommit, Commitment, CommitmentVersion};
+    use test_log::test;
+
+    const EL_URL: &str = "https://ethereum-rpc.publicnode.com";
+    const CL_URL: &str = "https://ethereum-beacon-api.publicnode.com";
+
+    #[test(tokio::test)]
+    #[ignore] // This queries actual RPC nodes, running only on demand.
+    async fn build_block_env() {
+        EthEvmEnv::builder()
+            .rpc(EL_URL.parse().unwrap())
+            .build()
+            .await
+            .unwrap();
+    }
+
+    #[test(tokio::test)]
+    #[ignore] // This queries actual RPC nodes, running only on demand.
+    async fn build_beacon_env() {
+        let provider = ProviderBuilder::new().on_builtin(EL_URL).await.unwrap();
+        let env = EthEvmEnv::builder()
+            .provider(&provider)
+            .beacon_api(CL_URL.parse().unwrap())
+            .block_number_or_tag(BlockNumberOrTag::Parent)
+            .build()
+            .await
+            .unwrap();
+        let commit = env.commit.commit(&env.header);
+
+        // the commitment should verify against the parent_beacon_block_root of the child
+        let child_block = provider
+            .get_block_by_number((env.header.number() + 1).into(), false)
+            .await
+            .unwrap();
+        let header_block = child_block.unwrap().header;
+        assert_eq!(
+            commit,
+            Commitment::new(
+                CommitmentVersion::Beacon as u16,
+                header_block.timestamp,
+                header_block.parent_beacon_block_root.unwrap()
+            )
+        );
+    }
+}

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -87,7 +87,7 @@ impl BlockNumberOrTag {
 pub(crate) type HostEvmEnv<D, H, C> = EvmEnv<ProofDb<D>, H, HostCommit<C>>;
 type EthHostEvmEnv<D, C> = EthEvmEnv<ProofDb<D>, HostCommit<C>>;
 
-/// Config wrapper on the host.
+/// Wrapper for the commit on the host.
 pub struct HostCommit<C> {
     inner: C,
     config_id: B256,

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -84,16 +84,16 @@ impl BlockNumberOrTag {
 }
 
 /// Alias for readability, do not make public.
-pub(crate) type HostEvmEnv<D, H, C> = EvmEnv<ProofDb<D>, H, C>;
-type EthHostEvmEnv<D, C> = EthEvmEnv<ProofDb<D>, C>;
+pub(crate) type HostEvmEnv<D, H, C> = EvmEnv<ProofDb<D>, H, HostCommit<C>>;
+type EthHostEvmEnv<D, C> = EthEvmEnv<ProofDb<D>, HostCommit<C>>;
 
-/// On the host we need to combine the [BlockHeaderCommit] with the config_id.
+/// Config wrapper on the host.
 pub struct HostCommit<C> {
     inner: C,
     config_id: B256,
 }
 
-impl EthHostEvmEnv<AlloyDb<Http<Client>, Ethereum, RootProvider<Http<Client>>>, HostCommit<()>> {
+impl EthHostEvmEnv<AlloyDb<Http<Client>, Ethereum, RootProvider<Http<Client>>>, ()> {
     /// Creates a new provable [EvmEnv] for Ethereum from an HTTP RPC endpoint.
     #[deprecated(since = "0.12.0", note = "use `EthEvmEnv::builder().rpc()` instead")]
     pub async fn from_rpc(url: Url, number: BlockNumberOrTag) -> Result<Self> {
@@ -105,7 +105,7 @@ impl EthHostEvmEnv<AlloyDb<Http<Client>, Ethereum, RootProvider<Http<Client>>>, 
     }
 }
 
-impl<T, N, P, H> HostEvmEnv<AlloyDb<T, N, P>, H, HostCommit<()>>
+impl<T, N, P, H> HostEvmEnv<AlloyDb<T, N, P>, H, ()>
 where
     T: Transport + Clone,
     N: Network,
@@ -131,7 +131,7 @@ where
     }
 }
 
-impl<D, H: EvmBlockHeader, C> HostEvmEnv<D, H, HostCommit<C>> {
+impl<D, H: EvmBlockHeader, C> HostEvmEnv<D, H, C> {
     /// Sets the chain ID and specification ID from the given chain spec.
     ///
     /// This will panic when there is no valid specification ID for the current block.
@@ -146,7 +146,7 @@ impl<D, H: EvmBlockHeader, C> HostEvmEnv<D, H, HostCommit<C>> {
     }
 }
 
-impl<T, P> EthHostEvmEnv<AlloyDb<T, Ethereum, P>, HostCommit<BeaconCommit>>
+impl<T, P> EthHostEvmEnv<AlloyDb<T, Ethereum, P>, BeaconCommit>
 where
     T: Transport + Clone,
     P: Provider<T, Ethereum>,
@@ -162,7 +162,7 @@ where
     }
 }
 
-impl<T, P> EthHostEvmEnv<AlloyDb<T, Ethereum, P>, HostCommit<()>>
+impl<T, P> EthHostEvmEnv<AlloyDb<T, Ethereum, P>, ()>
 where
     T: Transport + Clone,
     P: Provider<T, Ethereum>,

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -13,28 +13,29 @@
 // limitations under the License.
 
 //! Functionality that is only needed for the host and not the guest.
-use std::{fmt::Display, marker::PhantomData};
+use std::fmt::Display;
 
 use crate::{
-    beacon::BeaconInput,
+    beacon::BeaconCommit,
     block::BlockInput,
     ethereum::{EthBlockHeader, EthEvmEnv},
     host::db::ProviderDb,
-    EvmBlockHeader, EvmEnv, EvmInput,
+    ComposeInput, EvmBlockHeader, EvmEnv, EvmInput,
 };
 use alloy::{
-    network::{BlockResponse, Ethereum, Network},
-    providers::{Provider, ProviderBuilder, ReqwestProvider, RootProvider},
+    network::{Ethereum, Network},
+    providers::{Provider, RootProvider},
     rpc::types::BlockNumberOrTag as AlloyBlockNumberOrTag,
     transports::{
         http::{Client, Http},
         Transport,
     },
 };
-use anyhow::{anyhow, ensure, Context, Result};
-use db::{AlloyDb, ProofDb, ProviderConfig};
+use anyhow::{ensure, Result};
+use db::{AlloyDb, ProofDb};
 use url::Url;
 
+mod builder;
 pub mod db;
 
 /// A block number (or tag - "latest", "safe", "finalized").
@@ -81,9 +82,10 @@ impl BlockNumberOrTag {
 }
 
 /// Alias for readability, do not make public.
-pub(crate) type HostEvmEnv<D, H> = EvmEnv<ProofDb<D>, H>;
+pub(crate) type HostEvmEnv<D, H, C> = EvmEnv<ProofDb<D>, H, C>;
+type EthHostEvmEnv<D, C> = EthEvmEnv<ProofDb<D>, C>;
 
-impl EthEvmEnv<ProofDb<AlloyDb<Http<Client>, Ethereum, RootProvider<Http<Client>>>>> {
+impl EthHostEvmEnv<AlloyDb<Http<Client>, Ethereum, RootProvider<Http<Client>>>, ()> {
     /// Creates a new provable [EvmEnv] for Ethereum from an HTTP RPC endpoint.
     #[deprecated(since = "0.12.0", note = "use `EthEvmEnv::builder().rpc()` instead")]
     pub async fn from_rpc(url: Url, number: BlockNumberOrTag) -> Result<Self> {
@@ -95,7 +97,7 @@ impl EthEvmEnv<ProofDb<AlloyDb<Http<Client>, Ethereum, RootProvider<Http<Client>
     }
 }
 
-impl<T, N, P, H> HostEvmEnv<AlloyDb<T, N, P>, H>
+impl<T, N, P, H> HostEvmEnv<AlloyDb<T, N, P>, H, ()>
 where
     T: Transport + Clone,
     N: Network,
@@ -115,165 +117,40 @@ where
 
     /// Converts the environment into a [EvmInput] committing to a block hash.
     pub async fn into_input(self) -> Result<EvmInput<H>> {
-        Ok(EvmInput::Block(BlockInput::from_env(self).await?))
-    }
+        let input = BlockInput::from_proof_db(self.db.unwrap(), self.header).await?;
 
-    /// Returns the provider of the underlying [AlloyDb].
-    pub(crate) fn provider(&self) -> &P {
-        self.db().inner().provider()
+        Ok(EvmInput::Block(input))
     }
 }
 
-impl<T, P> HostEvmEnv<AlloyDb<T, Ethereum, P>, EthBlockHeader>
+impl<T, P> EthHostEvmEnv<AlloyDb<T, Ethereum, P>, BeaconCommit>
+where
+    T: Transport + Clone,
+    P: Provider<T, Ethereum>,
+{
+    /// Converts the environment into a [EvmInput] committing to a block hash.
+    pub async fn into_input(self) -> Result<EvmInput<EthBlockHeader>> {
+        let input = BlockInput::from_proof_db(self.db.unwrap(), self.header).await?;
+
+        Ok(EvmInput::Beacon(ComposeInput::new(input, self.commit)))
+    }
+}
+
+impl<T, P> EthHostEvmEnv<AlloyDb<T, Ethereum, P>, ()>
 where
     T: Transport + Clone,
     P: Provider<T, Ethereum>,
 {
     /// Converts the environment into a [EvmInput] committing to an Ethereum Beacon block root.
-    ///
-    /// This function assumes that the
-    /// [mainnet](https://github.com/ethereum/consensus-specs/blob/v1.4.0/configs/mainnet.yaml)
-    /// preset of the consensus specs is used.
-    ///
-    /// ```rust,no_run
-    /// # use alloy_primitives::{address, Address};
-    /// # use risc0_steel::{Contract, ethereum::EthEvmEnv};
-    /// # use url::Url;
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> anyhow::Result<()> {
-    /// // Create an environment.
-    /// let rpc_url = Url::parse("https://ethereum-rpc.publicnode.com")?;
-    /// let mut env = EthEvmEnv::builder().rpc(rpc_url).build().await?;
-    ///
-    /// // Preflight some contract calls...
-    /// # let address = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
-    /// # alloy::sol!( function balanceOf(address account) external view returns (uint); );
-    /// # let call = balanceOfCall{ account: Address::ZERO };
-    /// Contract::preflight(address, &mut env).call_builder(&call).call().await?;
-    ///
-    /// // Use EIP-4788 beacon commitments.
-    /// let beacon_api_url = Url::parse("https://ethereum-beacon-api.publicnode.com")?;
-    /// let input = env.into_beacon_input(beacon_api_url).await?;
-    /// # Ok(())
-    /// # }
+    #[deprecated(
+        since = "0.14.0",
+        note = "use `EvmEnv::builder().beacon_api()` instead"
+    )]
     pub async fn into_beacon_input(self, url: Url) -> Result<EvmInput<EthBlockHeader>> {
-        Ok(EvmInput::Beacon(
-            BeaconInput::from_env_and_endpoint(self, url).await?,
-        ))
-    }
-}
+        let commit =
+            BeaconCommit::from_header(self.header(), self.db().inner().provider(), url).await?;
+        let input = BlockInput::from_proof_db(self.db.unwrap(), self.header).await?;
 
-impl<H> EvmEnv<(), H> {
-    /// Creates a builder for building an environment.
-    ///
-    /// Create an Ethereum environment bast on the latest block:
-    /// ```rust,no_run
-    /// # use risc0_steel::ethereum::EthEvmEnv;
-    /// # use url::Url;
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> anyhow::Result<()> {
-    /// # let url = Url::parse("https://ethereum-rpc.publicnode.com")?;
-    /// let env = EthEvmEnv::builder().rpc(url).build().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn builder() -> EvmEnvBuilder<(), H> {
-        EvmEnvBuilder {
-            provider: (),
-            provider_config: ProviderConfig::default(),
-            block: BlockNumberOrTag::Latest,
-            phantom: PhantomData,
-        }
-    }
-}
-
-/// Builder for building an [EvmEnv] on the host.
-///
-/// The builder can be created using [EvmEnv::builder()].
-#[derive(Clone, Debug)]
-pub struct EvmEnvBuilder<P, H> {
-    provider: P,
-    provider_config: ProviderConfig,
-    block: BlockNumberOrTag,
-    phantom: PhantomData<H>,
-}
-
-impl EvmEnvBuilder<(), EthBlockHeader> {
-    /// Sets the Ethereum HTTP RPC endpoint that will be used by the [EvmEnv].
-    pub fn rpc(self, url: Url) -> EvmEnvBuilder<ReqwestProvider<Ethereum>, EthBlockHeader> {
-        self.provider(ProviderBuilder::new().on_http(url))
-    }
-}
-
-impl<H: EvmBlockHeader> EvmEnvBuilder<(), H> {
-    /// Sets the [Provider] that will be used by the [EvmEnv].
-    pub fn provider<T, N, P>(self, provider: P) -> EvmEnvBuilder<P, H>
-    where
-        T: Transport + Clone,
-        N: Network,
-        P: Provider<T, N>,
-        H: EvmBlockHeader + TryFrom<<N as Network>::HeaderResponse>,
-        <H as TryFrom<<N as Network>::HeaderResponse>>::Error: Display,
-    {
-        EvmEnvBuilder {
-            provider,
-            provider_config: self.provider_config,
-            block: self.block,
-            phantom: self.phantom,
-        }
-    }
-}
-
-impl<P, H> EvmEnvBuilder<P, H> {
-    /// Sets the block number.
-    pub fn block_number(self, number: u64) -> Self {
-        self.block_number_or_tag(BlockNumberOrTag::Number(number))
-    }
-
-    /// Sets the block number (or tag - "latest", "earliest", "pending").
-    pub fn block_number_or_tag(mut self, block: BlockNumberOrTag) -> Self {
-        self.block = block;
-        self
-    }
-
-    /// Sets the max number of storage keys to request in a single `eth_getProof` call.
-    ///
-    /// The optimal number depends on the RPC node and its configuration, but the default is 1000.
-    pub fn eip1186_proof_chunk_size(mut self, chunk_size: usize) -> Self {
-        assert_ne!(chunk_size, 0, "chunk size must be non-zero");
-        self.provider_config.eip1186_proof_chunk_size = chunk_size;
-        self
-    }
-
-    /// Builds the new provable [EvmEnv].
-    pub async fn build<T, N>(self) -> Result<EvmEnv<ProofDb<AlloyDb<T, N, P>>, H>>
-    where
-        T: Transport + Clone,
-        N: Network,
-        P: Provider<T, N>,
-        H: EvmBlockHeader + TryFrom<<N as Network>::HeaderResponse>,
-        <H as TryFrom<<N as Network>::HeaderResponse>>::Error: Display,
-    {
-        let provider = self.provider;
-        let number = self.block.into_rpc_type(&provider).await?;
-        let rpc_block = provider
-            .get_block_by_number(number, false)
-            .await
-            .context("eth_getBlockByNumber failed")?
-            .with_context(|| format!("block {} not found", number))?;
-        let header = rpc_block.header().clone();
-        let header: H = header
-            .try_into()
-            .map_err(|err| anyhow!("header invalid: {}", err))?;
-        let sealed_header = header.seal_slow();
-        log::info!("Environment initialized for block {}", sealed_header.seal());
-
-        let db = ProofDb::new(AlloyDb::new(
-            provider,
-            self.provider_config,
-            sealed_header.seal(),
-        ));
-
-        Ok(EvmEnv::new(db, sealed_header))
+        Ok(EvmInput::Beacon(ComposeInput::new(input, commit)))
     }
 }

--- a/steel/tests/corruption.rs
+++ b/steel/tests/corruption.rs
@@ -127,6 +127,7 @@ fn mock_anvil_guest(input: EthEvmInput) -> Commitment {
 async fn rpc_usdt_input() -> anyhow::Result<EthEvmInput> {
     let mut env = EthEvmEnv::builder()
         .rpc(RPC_URL.parse()?)
+        .beacon_api(BEACON_API_URL.parse()?)
         .block_number_or_tag(BlockNumberOrTag::Parent)
         .build()
         .await?;
@@ -136,7 +137,7 @@ async fn rpc_usdt_input() -> anyhow::Result<EthEvmInput> {
         .call()
         .await?;
 
-    env.into_beacon_input(BEACON_API_URL.parse()?).await
+    env.into_input().await
 }
 
 /// Loads the data from an existing JSON file, or creates it.


### PR DESCRIPTION
Previously, an input with a Beacon root commitment was created using the `into_beacon_input` method of the environment. This is inconsistent as all configuration should happen in the `EvmEnvBuilder`. 

Resolves #259 
Resolves WEB3-151