### PR TITLE
Add `JournalSeal` struct to encode `ffi` `prove` output

### DIFF
--- a/contracts/src/test/RiscZeroCheats.sol
+++ b/contracts/src/test/RiscZeroCheats.sol
@@ -30,6 +30,12 @@ import {Strings2} from "./utils/Strings2.sol";
 abstract contract RiscZeroCheats is CommonBase {
     using Strings2 for bytes;
 
+    /// @dev Journal and Seal struct used to decode the journal and seal from the `risc0-forge-ffi` `prove` command.
+    struct JournalSeal {
+        bytes journal;
+        bytes seal;
+    }
+
     /// @notice Returns whether we are using the prover and verifier in dev-mode, or fully verifying.
     /// @dev This environment variable, along with the respective options in the zkVM, are controlled
     ///      with the `RISC0_DEV_MODE` environment variable.
@@ -64,7 +70,8 @@ abstract contract RiscZeroCheats is CommonBase {
         imageRunnerInput[i++] = "prove";
         imageRunnerInput[i++] = elf_path;
         imageRunnerInput[i++] = input.toHexString();
-        return abi.decode(vm.ffi(imageRunnerInput), (bytes, bytes));
+        JournalSeal memory journalSeal = abi.decode(vm.ffi(imageRunnerInput), (JournalSeal));
+        return (journalSeal.journal, journalSeal.seal);
     }
 
     /// @notice Deploy either a test or fully verifying `RiscZeroGroth16Verifier` depending on `devMode()`.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+alloy::sol! {
+    /// Journal and Seal as returned by the `prove` command.
+    #[sol(all_derives)]
+    struct JournalSeal {
+        bytes journal;
+        bytes seal;
+    }
+}

--- a/ffi/src/main.rs
+++ b/ffi/src/main.rs
@@ -19,10 +19,11 @@ use std::{
     os::unix::io::{AsRawFd, FromRawFd},
 };
 
-use alloy::{primitives::Bytes, sol_types::SolValue};
+use alloy::sol_types::SolValue;
 use anyhow::{ensure, Context, Result};
 use clap::Parser;
 use risc0_ethereum_contracts::encode_seal;
+use risc0_forge_ffi::JournalSeal;
 use risc0_zkvm::{default_prover, ExecutorEnv, ProverOpts, VerifierContext};
 
 #[derive(Parser, Debug)]
@@ -64,7 +65,10 @@ pub fn main() -> Result<()> {
 fn prove_ffi(elf_path: String, input: Vec<u8>) -> Result<Vec<u8>> {
     let elf = std::fs::read(elf_path).expect("failed to read guest ELF");
     let (journal, seal) = prove(&elf, &input)?;
-    let calldata = (Bytes(journal.into()), Bytes(seal.into()));
+    let calldata = JournalSeal {
+        journal: journal.into(),
+        seal: seal.into(),
+    };
     Ok(calldata.abi_encode())
 }
 

--- a/ffi/tests/basic.rs
+++ b/ffi/tests/basic.rs
@@ -14,9 +14,10 @@
 
 use std::process::Command;
 
-use alloy::{primitives::Bytes, sol_types::SolValue};
+use alloy::sol_types::SolValue;
 use ffi_guests::{ECHO_ID, ECHO_PATH};
 use risc0_ethereum_contracts::encode_seal;
+use risc0_forge_ffi::JournalSeal;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, Receipt, ReceiptClaim};
 
 #[test]
@@ -36,7 +37,9 @@ fn basic_usage() {
     println!("{:#?}", &output);
 
     let output_bytes = hex::decode(output.stdout).unwrap();
-    let (journal, seal) = <(Bytes, Bytes)>::abi_decode(&output_bytes, true).unwrap();
+    let journal_seal = <JournalSeal>::abi_decode(&output_bytes, true).unwrap();
+    let journal = journal_seal.journal;
+    let seal = journal_seal.seal;
 
     assert_eq!(journal, hex::decode("deadbeef").unwrap());
     let expected_receipt = Receipt::new(
@@ -70,7 +73,9 @@ fn basic_usage_with_rust_log() {
     println!("{:#?}", &output);
 
     let output_bytes = hex::decode(output.stdout).unwrap();
-    let (journal, seal) = <(Bytes, Bytes)>::abi_decode(&output_bytes, true).unwrap();
+    let journal_seal = <JournalSeal>::abi_decode(&output_bytes, true).unwrap();
+    let journal = journal_seal.journal;
+    let seal = journal_seal.seal;
 
     assert_eq!(journal, hex::decode("deadbeef").unwrap());
     let expected_receipt = Receipt::new(


### PR DESCRIPTION
This PR fixes an Abu encoding/decoding issue on the ffi prove command by replacing the tuple `(Bytes, Bytes)` with a `JournalSeal` struct