### PR TITLE
Update dependencies and bump version to 1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
+checksum = "609d6ef5716e94875b19b91faf33ef041baff373d3fff70531424f372d27bbd2"
 dependencies = [
  "num_enum",
  "strum",
@@ -2599,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-forge-ffi"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["build", "contracts", "ffi", "ffi/guests", "steel"]
 
 [workspace.package]
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -11,10 +11,10 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 
 [workspace.dependencies]
 # Intra-workspace dependencies
-risc0-build-ethereum = { version = "1.1.2", default-features = false, path = "build" }
-risc0-ethereum-contracts = { version = "1.1.2", default-features = false, path = "contracts" }
-risc0-steel = { version = "0.13.2", default-features = false, path = "steel" }
-risc0-forge-ffi = { version = "1.1.2", default-features = false, path = "ffi" }
+risc0-build-ethereum = { version = "1.1.3", default-features = false, path = "build" }
+risc0-ethereum-contracts = { version = "1.1.3", default-features = false, path = "contracts" }
+risc0-steel = { version = "0.13.3", default-features = false, path = "steel" }
+risc0-forge-ffi = { version = "1.1.3", default-features = false, path = "ffi" }
 
 # risc0 monorepo dependencies.
 risc0-build = { version = "1.1.2", default-features = false }

--- a/examples/erc20-counter/Cargo.lock
+++ b/examples/erc20-counter/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
+checksum = "609d6ef5716e94875b19b91faf33ef041baff373d3fff70531424f372d27bbd2"
 dependencies = [
  "num_enum",
  "strum",
@@ -2670,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/examples/erc20-counter/methods/guest/Cargo.lock
+++ b/examples/erc20-counter/methods/guest/Cargo.lock
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",

--- a/examples/erc20/Cargo.lock
+++ b/examples/erc20/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
+checksum = "609d6ef5716e94875b19b91faf33ef041baff373d3fff70531424f372d27bbd2"
 dependencies = [
  "num_enum",
  "strum",
@@ -2521,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/examples/erc20/methods/guest/Cargo.lock
+++ b/examples/erc20/methods/guest/Cargo.lock
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",

--- a/examples/governance/Cargo.lock
+++ b/examples/governance/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
+checksum = "609d6ef5716e94875b19b91faf33ef041baff373d3fff70531424f372d27bbd2"
 dependencies = [
  "num_enum",
  "strum",
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "alloy 0.3.3",
  "anyhow",

--- a/examples/governance/methods/guest/Cargo.lock
+++ b/examples/governance/methods/guest/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "risc0-binfmt"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "anyhow",
  "borsh",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "risc0-circuit-recursion"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "risc0-circuit-rv32im"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "anyhow",
  "metal",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "risc0-core"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "risc0-groth16"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkp"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "anyhow",
  "blake2",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "anyhow",
  "borsh",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm-platform"
 version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?branch=main#12f0a30d1d273360389bada897ad0035a8ad29c5"
+source = "git+https://github.com/risc0/risc0?branch=main#f61379bf69b24d56e49d6af96a3b284961dcc498"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/token-stats/Cargo.lock
+++ b/examples/token-stats/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
+checksum = "609d6ef5716e94875b19b91faf33ef041baff373d3fff70531424f372d27bbd2"
 dependencies = [
  "num_enum",
  "strum",
@@ -2523,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/examples/token-stats/methods/guest/Cargo.lock
+++ b/examples/token-stats/methods/guest/Cargo.lock
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-steel"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-steel"
 description = "Query Ethereum state, or any other EVM-based blockchain state within the RISC Zero zkVM."
-version = "0.13.2"
+version = "0.13.3"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
This PR bumps the version number to 1.1.3 for the workspace, and 0.13.3 for Steel.