### PR TITLE
WEB3-168: fix: pin alloy-core to v0.8.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,11 @@ risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-
 
 # Alloy guest dependencies
 alloy-consensus = { version = "0.4" }
-alloy-primitives = { version = "0.8" }
 alloy-rlp = { version = "0.3.8" }
 alloy-rlp-derive = { version = "0.3.8" }
-alloy-sol-types = { version = "0.8" }
+# Pin alloy-core to 0.8.5 to avoid using foldhash as default hasher
+alloy-primitives = { version = "=0.8.5" }
+alloy-sol-types = { version = "=0.8.5" }
 
 # Alloy host dependencies
 alloy = { version = "0.4" }


### PR DESCRIPTION
With v0.8.6 alloy-core switched its default hasher to foldhash, which depends on rand and chrono. To avoid issues in the guest we pin the version to 0.8.5