### PR TITLE
WEB3-193: redirect README links to see both directories and README as well

### DIFF
--- a/steel/README.md
+++ b/steel/README.md
@@ -40,9 +40,9 @@ This documentation covers the core concepts of Steel. After reading, you will un
 
 The RISC Zero [dev docs][dev-docs] are a great place to start to understand the zkVM in detail. If you have any questions, and/or just want to hang out with other builders, please join the [RISC Zero Discord][risczero-discord].
 
-[Steel examples]: ../examples/README.md
-[ERC20 Counter]: ../examples/erc20-counter/README.md
-[create-steel-app]: docs/create-steel-app/README.md
+[Steel examples]: ../examples
+[ERC20 Counter]: ../examples/erc20-counter
+[create-steel-app]: docs/create-steel-app
 [video tutorial]: https://www.loom.com/share/0e2ede7b9d50464fb729819a8bd24e05?sid=3009618b-38ea-449a-90dc-9b39ef569c67
 [Introducing Steel 1.0]: https://risczero.com/blog/introducing-steel-1.0
 [What is Steel?]: docs/what-is-steel.md

--- a/steel/docs/how-does-steel-work.md
+++ b/steel/docs/how-does-steel-work.md
@@ -118,7 +118,7 @@ Aggregation is a key feature of [Boundless][boundless-website]
 <---- [What is Steel?] | [Steel Commitments] ---->
 
 [sol-macro]: https://alloy.rs/examples/sol-macro/index.html
-[here]: https://github.com/risc0/risc0-ethereum/blob/main/examples/erc20-counter/README.md
+[here]: https://github.com/risc0/risc0-ethereum/blob/main/examples/erc20-counter
 [guest program]: https://dev.risczero.com/terminology#guest-program
 [revm]: https://docs.rs/revm/latest/revm/
 [host program]: https://dev.risczero.com/terminology#host-program


### PR DESCRIPTION
For example, changing a link which points to "examples/README.md" to "examples/" directly. In practice this will change the outcome as so:

From:
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/d1f72970-5030-44da-b40e-aad26dbedf39">

to:

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/deb0beab-6392-40cb-95a8-747c770774db">
