### PR TITLE
WEB3-209: Make `EvmEnvBuilder` public

### DIFF
--- a/steel/CHANGELOG.md
+++ b/steel/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ⚡️ Features
 
 - Introduce `HistoryInput`, which decouples the EVM execution block from the commitment block. This allows verification against a commitment that is more recent than the execution, allowing secure interaction with the historical state. This functionality is currently marked "unstable" and must be enabled using the `unstable-history` feature.
+- Make `EvmEnvBuilder` public.
 
 ## [1.1.4](https://github.com/risc0/risc0-ethereum/releases/tag/v1.1.4) - 2024-10-07
 

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -41,6 +41,8 @@ use url::Url;
 mod builder;
 pub mod db;
 
+pub use builder::EvmEnvBuilder;
+
 /// A block number (or tag - "latest", "safe", "finalized").
 /// This enum is used to specify which block to query when interacting with the blockchain.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]


### PR DESCRIPTION
 `EvmEnvBuilder` is returned by the public method `EthEvmEnv::builder()`, so the type should also be public.