### PR TITLE
WEB3-229: fix: run history corruption tests only when the feature is enabled

### DIFF
--- a/steel/tests/corruption.rs
+++ b/steel/tests/corruption.rs
@@ -422,6 +422,7 @@ async fn corrupt_beacon_proof_length() {
 #[cfg(feature = "unstable-history")]
 mod history {
     use super::*;
+    use test_log::test;
 
     /// Creates `EthEvmInput::History` using live RPC nodes preflighting `IERC20(USDT).balanceOf(0x0)`.
     async fn rpc_usdt_history_input() -> anyhow::Result<EthEvmInput> {


### PR DESCRIPTION
Otherwise the integration tests will fail to compile if the `unstable-history` feature is not enabled.