### PR TITLE
WEB3-236: Add deployment tests to confirm deployment.toml against chain state

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -71,7 +71,23 @@
 
    2. After the timelock delay has passed (7 days on mainnet chains and 1 second on testnet), finsh the operation to add the new verifier to the router.
 
-   3. Document the new addresses and version in the `dev.risczero.com` docs.
+   3. Run the deployment tests to confirm that the state recorded in `deployment.toml` matches the state of the contracts deployed on-chain.
+
+      You can run the tests against a single chain with the following command:
+
+      ```sh
+      # In the contracts directory.
+      FOUNDRY_PROFILE=deployment-test forge test -vv --fork-url="$RPC_URL"
+      ```
+
+      You can run the tests against all supported chains with the following oneliner:
+
+      ```sh
+      # In the contracts directory.
+      for rpcurl in $(yq eval -e ".chains[].rpc-url" deployment_secrets.toml); do FOUNDRY_PROFILE=deployment-test forge test -vv --fork-url="$rpcurl"; done
+      ```
+
+   4. Document the new addresses and version in the `dev.risczero.com` docs.
 
      Use [contracts/generate_contract_address_table.py] to generate the tables. Python 3.11+ is required.
 

--- a/contracts/deployment-test/Deployment.t.sol
+++ b/contracts/deployment-test/Deployment.t.sol
@@ -73,6 +73,14 @@ contract DeploymentTest is Test {
             timelockController.hasRole(timelockController.CANCELLER_ROLE(), deployment.admin),
             "admin does not have canceller role"
         );
+        uint256 deployedDelay = timelockController.getMinDelay();
+        console2.log(
+            "Min delay on timelock controller is %d; expected value is %d", deployedDelay, deployment.timelockDelay
+        );
+        require(
+            timelockController.getMinDelay() == deployment.timelockDelay,
+            "timelock controller min delay is not as expected"
+        );
     }
 
     function testVerifierRouterIsConfiguredProperly() external view {

--- a/contracts/deployment-test/Deployment.t.sol
+++ b/contracts/deployment-test/Deployment.t.sol
@@ -1,0 +1,120 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.9;
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import {TimelockController} from "openzeppelin/contracts/governance/TimelockController.sol";
+import {RiscZeroVerifierRouter} from "../src/RiscZeroVerifierRouter.sol";
+import {IRiscZeroVerifier} from "../src/IRiscZeroVerifier.sol";
+import {ConfigLoader, Deployment, DeploymentLib, VerifierDeployment} from "../src/config/Config.sol";
+
+/// Test designed to be run against a chain with an active deployment of the RISC Zero contracts.
+/// Checks that the deployment matches what is recorded in the deployment.toml file.
+contract DeploymentTest is Test {
+    using DeploymentLib for Deployment;
+
+    Deployment internal deployment;
+
+    TimelockController internal timelockController;
+    RiscZeroVerifierRouter internal router;
+
+    function setUp() external {
+        string memory configPath = vm.envOr("DEPLOYMENT_CONFIG", string("./deployment.toml"));
+        console2.log("Loading deployment config from %s", configPath);
+        ConfigLoader.loadDeploymentConfig(configPath).copyTo(deployment);
+
+        // Wrap the control addresses with their respective contract implementations.
+        // NOTE: These addresses may be zero, so this does not guarantee contracts are deployed.
+        timelockController = TimelockController(payable(deployment.timelockController));
+        router = RiscZeroVerifierRouter(deployment.router);
+    }
+
+    function testAdminIsSet() external view {
+        require(deployment.admin != address(0), "no admin address is set");
+    }
+
+    function testTimelockControllerIsDeployed() external view {
+        require(address(timelockController) != address(0), "no timelock controller address is set");
+        require(
+            keccak256(address(timelockController).code) != keccak256(bytes("")), "timelock controller code is empty"
+        );
+    }
+
+    function testRouterIsDeployed() external view {
+        require(address(router) != address(0), "no router address is set");
+        require(keccak256(address(router).code) != keccak256(bytes("")), "router code is empty");
+    }
+
+    function testTimelockControllerIsConfiguredProperly() external view {
+        require(
+            timelockController.hasRole(timelockController.PROPOSER_ROLE(), deployment.admin),
+            "admin does not have proposer role"
+        );
+        require(
+            timelockController.hasRole(timelockController.EXECUTOR_ROLE(), deployment.admin),
+            "admin does not have executor role"
+        );
+        require(
+            timelockController.hasRole(timelockController.CANCELLER_ROLE(), deployment.admin),
+            "admin does not have canceller role"
+        );
+    }
+
+    function testVerifierRouterIsConfiguredProperly() external view {
+        require(router.owner() == address(timelockController), "router is not owned by timelock controller");
+
+        for (uint256 i = 0; i < deployment.verifiers.length; i++) {
+            VerifierDeployment storage verifierConfig = deployment.verifiers[i];
+            console2.log(
+                "Checking for deployment to the router of verifier with selector %x and version %s",
+                uint256(uint32(verifierConfig.selector)),
+                verifierConfig.version
+            );
+            if (verifierConfig.unroutable) {
+                // When a verifier is specified to be unroutable, confirm that it is indeed not added to the router.
+                try router.getVerifier(verifierConfig.selector) {
+                    revert("expected router.getVerifier to revert");
+                } catch (bytes memory err) {
+                    // NOTE: We could allot SelectorRemoved as well here.
+                    require(
+                        keccak256(err)
+                            == keccak256(
+                                abi.encodeWithSelector(
+                                    RiscZeroVerifierRouter.SelectorUnknown.selector, verifierConfig.selector
+                                )
+                            )
+                    );
+                    console2.log(
+                        "Verifier with selector %s is unroutable, as configured",
+                        uint256(uint32(verifierConfig.selector))
+                    );
+                }
+                continue;
+            }
+
+            IRiscZeroVerifier verifierImpl = router.getVerifier(verifierConfig.selector);
+            require(address(verifierImpl) != address(0), "verifier impl returned the zero address");
+            require(keccak256(address(verifierImpl).code) != keccak256(bytes("")), "verifier impl has no deployed code");
+            // TODO: When SELECTOR is added to the public verifier interface, also check the verifier has the expected selector.
+        }
+    }
+
+    function testNothing() external view {
+        console2.log("deployment.verifiers.length %d", deployment.verifiers.length);
+    }
+}

--- a/contracts/deployment-test/Deployment.t.sol
+++ b/contracts/deployment-test/Deployment.t.sol
@@ -113,8 +113,4 @@ contract DeploymentTest is Test {
             // TODO: When SELECTOR is added to the public verifier interface, also check the verifier has the expected selector.
         }
     }
-
-    function testNothing() external view {
-        console2.log("deployment.verifiers.length %d", deployment.verifiers.length);
-    }
 }

--- a/contracts/deployment-test/Deployment.t.sol
+++ b/contracts/deployment-test/Deployment.t.sol
@@ -100,7 +100,7 @@ contract DeploymentTest is Test {
                             )
                     );
                     console2.log(
-                        "Verifier with selector %s is unroutable, as configured",
+                        "Verifier with selector %x is unroutable, as configured",
                         uint256(uint32(verifierConfig.selector))
                     );
                 }

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -352,6 +352,7 @@ estop = "0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319"
 
 [[chains.linea-sepolia.verifiers]]
 version = "1.1.0-rc.3"
+unroutable = true
 selector = "0x50bd1769"
 verifier = "0xf70aBAb028Eb6F4100A24B203E113D94E87DE93C"
 estop = "0x44c220f0598345195cE99AD6A57aDfFcb9Ea33e7"

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -41,6 +41,7 @@ version = "1.1.0-rc.2"
 selector = "0x4c630d87"
 verifier = "0xf4D938c73Bcc124e02A2D6c7557e98838B5E91B4"
 estop = "0x1C182869A6bF84DfAc0a70B46e2f9b3aeE9100e1"
+unroutable = true
 
 [[chains.ethereum-sepolia.verifiers]]
 version = "1.1.0-rc.3"

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -12,6 +12,8 @@ router = "0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319"
 
 # TODO: Add information for 1.0 contracts.
 [[chains.ethereum-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0x5a99469f18a5863D3258E577892589386dFD965E"
 estop = "0xB839eA7bBA8e6bB2893ca5252F3f3C13323D74F7"
@@ -38,10 +40,10 @@ router = "0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187"
 
 [[chains.ethereum-sepolia.verifiers]]
 version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xf4D938c73Bcc124e02A2D6c7557e98838B5E91B4"
 estop = "0x1C182869A6bF84DfAc0a70B46e2f9b3aeE9100e1"
-unroutable = true
 
 [[chains.ethereum-sepolia.verifiers]]
 version = "1.1.0-rc.3"
@@ -64,6 +66,8 @@ timelock-controller = "0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319"
 router = "0xf70aBAb028Eb6F4100A24B203E113D94E87DE93C"
 
 [[chains.ethereum-holesky.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xDC986a09728F76110FF666eE7b20d99086501d15"
 estop = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
@@ -89,6 +93,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.arbitrum-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -114,6 +120,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.arbitrum-sepolia.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -139,6 +147,8 @@ timelock-controller = "0xDC986a09728F76110FF666eE7b20d99086501d15"
 router = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
 
 [[chains.avalanche-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -164,6 +174,8 @@ timelock-controller = "0xDC986a09728F76110FF666eE7b20d99086501d15"
 router = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
 
 [[chains.avalanche-fuji.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -189,6 +201,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.base-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -214,6 +228,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.base-sepolia.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0x84b943E31e7fAe6072ce5F75eb4694C7D5F9b0cF"
 estop = "0x5E36f0D56741013d864d8FEb5950AB0E7Eff9Ab1"
@@ -239,6 +255,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.optimism-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -266,6 +284,8 @@ router = "0xB369b4dd27FBfb59921d3A4a3D23AC2fc32FB908"
 # NOTE: 1.0 was not deployed to OP Sepolia.
 
 [[chains.optimism-sepolia.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -291,6 +311,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.linea-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
@@ -322,6 +344,8 @@ router = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
 # As a result, the router is deployed, but it is empty and useless.
 
 [[chains.linea-sepolia.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
 estop = "0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319"
@@ -347,6 +371,8 @@ timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.polygon-zkevm-mainnet.verifiers]]
+version = "1.1.0-rc.2"
+unroutable = true
 selector = "0x4c630d87"
 verifier = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
 estop = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -271,7 +271,7 @@ estop = "0x5E36f0D56741013d864d8FEb5950AB0E7Eff9Ab1"
 
 [chains.optimism-sepolia]
 name = "Optimism Sepolia"
-id = 11110
+id = 11155420
 etherscan-url = "https://sepolia-optimism.etherscan.io/"
 
 # Accounts
@@ -386,9 +386,10 @@ estop = "0x5E36f0D56741013d864d8FEb5950AB0E7Eff9Ab1"
 
 ###
 
+# NOTE: This is the Cardona testnet, which uses Sepolia ETH as it's native currency.
 [chains.polygon-zkevm-testnet]
 name = "Polygon zkEVM Testnet"
-id = 1442
+id = 2442
 etherscan-url = "https://cardona-zkevm.polygonscan.com/"
 
 # Accounts

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -8,6 +8,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
+timelock-delay = 604800
 router = "0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319"
 
 # TODO: Add information for 1.0 contracts.
@@ -36,6 +37,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0xB4E3306129208cC8e6E75157f75f62eAe0B920a0"
+timelock-delay = 1
 router = "0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187"
 
 [[chains.ethereum-sepolia.verifiers]]
@@ -63,6 +65,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0x8EaB2D97Dfce405A1692a21b3ff3A172d593D319"
+timelock-delay = 1
 router = "0xf70aBAb028Eb6F4100A24B203E113D94E87DE93C"
 
 [[chains.ethereum-holesky.verifiers]]
@@ -90,6 +93,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 604800
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.arbitrum-mainnet.verifiers]]
@@ -117,6 +121,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 1
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.arbitrum-sepolia.verifiers]]
@@ -144,6 +149,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0xDC986a09728F76110FF666eE7b20d99086501d15"
+timelock-delay = 604800
 router = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
 
 [[chains.avalanche-mainnet.verifiers]]
@@ -171,6 +177,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0xDC986a09728F76110FF666eE7b20d99086501d15"
+timelock-delay = 1
 router = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
 
 [[chains.avalanche-fuji.verifiers]]
@@ -198,6 +205,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 604800
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.base-mainnet.verifiers]]
@@ -225,6 +233,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 1
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.base-sepolia.verifiers]]
@@ -252,6 +261,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 604800
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.optimism-mainnet.verifiers]]
@@ -279,6 +289,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0x2DEfEA335392bb62d01f74e338697C7B31De254C"
+timelock-delay = 1
 router = "0xB369b4dd27FBfb59921d3A4a3D23AC2fc32FB908"
 
 # NOTE: 1.0 was not deployed to OP Sepolia.
@@ -308,6 +319,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 604800
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.linea-mainnet.verifiers]]
@@ -335,6 +347,7 @@ admin = "0x3a54A45E44a71020Bd0Af42063B9f23e8b9E387D"
 
 # Contracts
 timelock-controller = "0xBDaEd5bbf8016AfD05Fc4659572e5fEb5854aAD4"
+timelock-delay = 1
 router = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
 
 # NOTE: As of the 1.1.0-rc.2 deployment on August 21, Forge could not verify the contracts.
@@ -369,6 +382,7 @@ admin = "0xF616A4f81857CFEe54A4A049Ec187172574bd412"
 
 # Contracts
 timelock-controller = "0xdc986a09728f76110ff666ee7b20d99086501d15"
+timelock-delay = 604800
 router = "0x0b144e07a0826182b6b59788c34b32bfa86fb711"
 
 [[chains.polygon-zkevm-mainnet.verifiers]]

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,7 +1,15 @@
 [profile.default]
 src = "src"
 out = "out"
+test = "test"
 libs = ["../lib"]
 ffi = true
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# Profile used to run deployment tests, which check the correctness of contracts as deployed.
+# TIP: You can select this profile by setting env var FOUNDRY_PROFILE=deployment-test
+[profile.deployment-test]
+test = "./deployment-test"
+#match_path = "contracts/deployment-test/*"
+fs_permissions = [{ access = "read", path = "deployment.toml" }]
+
+# See more config options https://book.getfoundry.sh/static/config.default.toml

--- a/contracts/src/config/Config.sol
+++ b/contracts/src/config/Config.sol
@@ -89,6 +89,7 @@ library ConfigLoader {
             console2.log("Using chain key %s set via environment variable", chainKey);
         } else {
             // Since no chain key is set, select the default one based on the chainId
+            console2.log("Determining chain key from chain ID %d", block.chainid);
             string[] memory chainKeys = VM.parseTomlKeys(configToml, ".chains");
             for (uint256 i = 0; i < chainKeys.length; i++) {
                 if (stdToml.readUint(configToml, string.concat(".chains.", chainKeys[i], ".id")) == block.chainid) {

--- a/contracts/src/config/Config.sol
+++ b/contracts/src/config/Config.sol
@@ -1,0 +1,167 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {Vm} from "forge-std/Vm.sol";
+import {console2} from "forge-std/console2.sol";
+import {stdToml} from "forge-std/StdToml.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+/// Deployment a single verifier.
+///
+/// Many verifiers may be part of a deployment, with the router serving the purpose of making them
+/// all accessible at a single address.
+struct VerifierDeployment {
+    string version;
+    bytes4 selector;
+    address verifier;
+    address estop;
+    /// Specifies that this verifier is not deployed to the verifier router.
+    /// Default is false since most of the verifiers in the config are intended to be routable.
+    bool unroutable;
+}
+
+/// Deployment of the RISC Zero contracts on a particular chain.
+///
+/// The deployment.toml file contains a number of deployments. Each is indexed by a "chain key",
+/// such as "ethereum-mainnet". This struct represents the values in one of those deployments.
+struct Deployment {
+    /// A friendly name for the network, such as "Ethereum Mainnet".
+    string name;
+    /// Chain ID for the network.
+    uint256 chainId;
+    /// Admin address for emergency stop contracts on this network, as well as the proposer for the
+    /// timelock controller that acts as the admin for the router.
+    address admin;
+    /// Address of the verifier router in this deployment.
+    address router;
+    /// Address of the timelock control in this deployment, which is set as the admin of the router.
+    address timelockController;
+    /// Deployed verifier implementations.
+    VerifierDeployment[] verifiers;
+}
+
+library DeploymentLib {
+    /// Copy the deployment from memory to storage.
+    /// Solidity does not allow this to be done via the assignment operator.
+    function copyTo(Deployment memory mem, Deployment storage stor) internal {
+        stor.name = mem.name;
+        stor.chainId = mem.chainId;
+        stor.admin = mem.admin;
+        stor.router = mem.router;
+        stor.timelockController = mem.timelockController;
+        delete stor.verifiers;
+        for (uint256 i = 0; i < mem.verifiers.length; i++) {
+            stor.verifiers.push(mem.verifiers[i]);
+        }
+    }
+}
+
+/// @notice Loader for the deployment config from a given deployment.toml file.
+/// @dev This library uses Forge cheat code and can only be used in Forge script or test environments.
+library ConfigLoader {
+    /// Reference the vm address without needing to inherit from Script.
+    Vm private constant VM = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    /// Given the contents of the deployment.toml file, determine the active chain key.
+    /// This function first checks the "CHAIN_KEY" environment variable and uses the value if set.
+    /// If not set, this function looks for a deployment in the given TOML with a matching chainId
+    /// field and returns the first matching result.
+    function determineChainKey(string memory configToml) internal view returns (string memory) {
+        // Get the config profile from the environment variable, or leave it empty
+        string memory chainKey = VM.envOr("CHAIN_KEY", string(""));
+
+        if (bytes(chainKey).length != 0) {
+            console2.log("Using chain key %s set via environment variable", chainKey);
+        } else {
+            // Since no chain key is set, select the default one based on the chainId
+            string[] memory chainKeys = VM.parseTomlKeys(configToml, ".chains");
+            for (uint256 i = 0; i < chainKeys.length; i++) {
+                if (stdToml.readUint(configToml, string.concat(".chains.", chainKeys[i], ".id")) == block.chainid) {
+                    chainKey = chainKeys[i];
+                    console2.log("Using chain key %s from the config for chain ID %d", chainKey, block.chainid);
+                    break;
+                }
+            }
+        }
+        require(bytes(chainKey).length != 0, "failed to determine the chain key in config TOML");
+
+        // Double check that there chain-key and connected chain ID match. TODO: Is this too restrictive?
+        uint256 chainId = stdToml.readUint(configToml, string.concat(".chains.", chainKey, ".id"));
+        require(
+            chainId == block.chainid, "chosen chain key is associated with chain ID that does not match connected chain"
+        );
+
+        return chainKey;
+    }
+
+    function loadDeploymentConfig(string memory configFilePath) internal view returns (Deployment memory) {
+        string memory configToml = VM.readFile(configFilePath);
+        string memory chainKey = determineChainKey(configToml);
+        return ConfigParser.parseConfig(configToml, chainKey);
+    }
+}
+
+/// @notice Parser for the deployment config given a TOML string.
+/// @dev This library uses Forge cheat code and can only be used in Forge script or test environments.
+library ConfigParser {
+    using SafeCast for uint256;
+
+    /// Reference the vm address without needing to inherit from Script.
+    Vm private constant VM = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    function parseConfig(string memory config, string memory chainKey) internal view returns (Deployment memory) {
+        string memory chain = string.concat(".chains.", chainKey);
+
+        Deployment memory deploymentConfig;
+        deploymentConfig.name = stdToml.readString(config, string.concat(chain, ".name"));
+        deploymentConfig.chainId = stdToml.readUint(config, string.concat(chain, ".id"));
+        deploymentConfig.admin = stdToml.readAddressOr(config, string.concat(chain, ".admin"), address(0));
+        deploymentConfig.router = stdToml.readAddressOr(config, string.concat(chain, ".router"), address(0));
+        deploymentConfig.timelockController =
+            stdToml.readAddressOr(config, string.concat(chain, ".timelock-controller"), address(0));
+
+        // Iterate over the verifier struct entries to get the length;
+        // NOTE: We do this because Solidity doesn't support dynamic arrays in memory :|
+        uint256 verifiersLength = 0;
+        string memory verifierKey = string.concat(chain, ".verifiers[", VM.toString(verifiersLength), "]");
+        while (stdToml.keyExists(config, verifierKey)) {
+            verifiersLength++;
+            verifierKey = string.concat(chain, ".verifiers[", VM.toString(verifiersLength), "]");
+        }
+        deploymentConfig.verifiers = new VerifierDeployment[](verifiersLength);
+
+        // Iterate over the verifier struct entries and parse them.
+        uint256 verifierIndex = 0;
+        verifierKey = string.concat(chain, ".verifiers[", VM.toString(verifierIndex), "]");
+        while (stdToml.keyExists(config, verifierKey)) {
+            VerifierDeployment memory verifier;
+            verifier.version = stdToml.readStringOr(config, string.concat(verifierKey, ".version"), "");
+            verifier.selector = bytes4(stdToml.readUint(config, string.concat(verifierKey, ".selector")).toUint32());
+            verifier.verifier = stdToml.readAddress(config, string.concat(verifierKey, ".verifier"));
+            verifier.estop = stdToml.readAddress(config, string.concat(verifierKey, ".estop"));
+            verifier.unroutable = stdToml.readBoolOr(config, string.concat(verifierKey, ".unroutable"), false);
+
+            deploymentConfig.verifiers[verifierIndex] = verifier;
+
+            verifierIndex++;
+            verifierKey = string.concat(chain, ".verifiers[", VM.toString(verifierIndex), "]");
+        }
+
+        return deploymentConfig;
+    }
+}

--- a/contracts/src/config/Config.sol
+++ b/contracts/src/config/Config.sol
@@ -51,6 +51,8 @@ struct Deployment {
     address router;
     /// Address of the timelock control in this deployment, which is set as the admin of the router.
     address timelockController;
+    /// Min delay configured on the timelock controller.
+    uint256 timelockDelay;
     /// Deployed verifier implementations.
     VerifierDeployment[] verifiers;
 }
@@ -64,6 +66,7 @@ library DeploymentLib {
         stor.admin = mem.admin;
         stor.router = mem.router;
         stor.timelockController = mem.timelockController;
+        stor.timelockDelay = mem.timelockDelay;
         delete stor.verifiers;
         for (uint256 i = 0; i < mem.verifiers.length; i++) {
             stor.verifiers.push(mem.verifiers[i]);
@@ -135,6 +138,9 @@ library ConfigParser {
         deploymentConfig.router = stdToml.readAddressOr(config, string.concat(chain, ".router"), address(0));
         deploymentConfig.timelockController =
             stdToml.readAddressOr(config, string.concat(chain, ".timelock-controller"), address(0));
+        if (deploymentConfig.timelockController != address(0)) {
+            deploymentConfig.timelockDelay = stdToml.readUint(config, string.concat(chain, ".timelock-delay"));
+        }
 
         // Iterate over the verifier struct entries to get the length;
         // NOTE: We do this because Solidity doesn't support dynamic arrays in memory :|


### PR DESCRIPTION
Adds deployment tests that can be run against public networks to confirm that the setting and state recorded in `deployment.toml` are applied correctly.