### PR TITLE
WEB3-240: Re-export alloy from risc0-ethereum-contracts and risc0-steel

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -12,12 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod groth16;
+
+/// Re-export of [alloy], provided to ensure that the correct version of the types used in the
+/// public API are available in case multiple versions of [alloy] are in use.
+///
+/// Because [alloy] is a v0.x crate, it is not covered under the semver policy of this crate.
+pub use alloy;
+
 alloy::sol!(
     #![sol(rpc, all_derives)]
     "src/IRiscZeroVerifier.sol"
 );
-
-pub mod groth16;
 
 use anyhow::{bail, Result};
 use risc0_zkvm::{sha::Digestible, InnerReceipt};

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -19,6 +19,7 @@
 /// public API are available in case multiple versions of [alloy] are in use.
 ///
 /// Because [alloy] is a v0.x crate, it is not covered under the semver policy of this crate.
+#[cfg(feature = "host")]
 pub use alloy;
 
 use ::serde::{Deserialize, Serialize};

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -15,6 +15,12 @@
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+/// Re-export of [alloy], provided to ensure that the correct version of the types used in the
+/// public API are available in case multiple versions of [alloy] are in use.
+///
+/// Because [alloy] is a v0.x crate, it is not covered under the semver policy of this crate.
+pub use alloy;
+
 use ::serde::{Deserialize, Serialize};
 use alloy_primitives::{uint, BlockNumber, Sealable, Sealed, B256, U256};
 use alloy_sol_types::SolValue;


### PR DESCRIPTION
One the common pieces of feedback we do from the Boundless private devnet was that `alloy` versioning was one of the biggest challenges. In particular, a developer would encounter a type mismatch error where "alloy::Foo is the not the same as alloy::Foo", which is a somewhat difficult to debug issue related to having two version of `alloy` in your crates tree. Because `alloy` is pre-1.0 and changing often, there is no silver bullet here.

One rule of thumb though is that an types that appear in the public interface of a crate should be (re-)exported from that crate. In our case, we do have `alloy` types in our public interface. So, if we apply this rule, we should export the types we use from `alloy`, and the easiest way to do so is to re-export the `alloy` crate. This helps with the versioning challenges because if the project ends up needing two distinct versions of `alloy` (e.g. one dependency specifies 0.4 and another 0.6) then the developer can use the re-exported `alloy` as an anchor for any places they are using `risc0-steel` or `risc0-ethereum-contracts`.