### PR TITLE
WEB3-242: Add --locked to release branch cargo runs

### DIFF
--- a/.github/scripts/cargo-clippy.sh
+++ b/.github/scripts/cargo-clippy.sh
@@ -4,7 +4,7 @@ set -e
 clippy(){
   while read path; do
     printf "Project: %s\n" "$path"
-    cargo clippy --workspace --all-targets --all-features --manifest-path "$path"
+    cargo clippy $CARGO_LOCKED --workspace --all-targets --all-features --manifest-path "$path"
   done
 }
 

--- a/.github/scripts/cargo-test.sh
+++ b/.github/scripts/cargo-test.sh
@@ -4,8 +4,8 @@ set -e
 build_test(){
   while read path; do
     printf "Project: %s\n" "$path"
-    cargo build --workspace --all-features --manifest-path "$path"
-    cargo test --workspace --all-features --manifest-path "$path"
+    cargo build $CARGO_LOCKED --workspace --all-features --manifest-path "$path"
+    cargo test $CARGO_LOCKED --workspace --all-features --manifest-path "$path"
   done
 }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ env:
   RISC0_TOOLCHAIN_VERSION: r0.1.81.0
   RISC0_MONOREPO_REF: "main"
   IS_RELEASE_BRANCH: ${{ startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'refs/heads/release-') }}
-  CARGO_LOCKED: ${{ env.IS_RELEASE_BRANCH && '--locked' || '' }}
+  CARGO_LOCKED: ${{ fromJson(toJson(env.IS_RELEASE_BRANCH && '--locked' || '')) }}
 
 jobs:
   # see: https://github.com/orgs/community/discussions/26822

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_TOOLCHAIN_VERSION: r0.1.81.0
   RISC0_MONOREPO_REF: "main"
+  IS_RELEASE_BRANCH: ${{ startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'refs/heads/release-') }}
+  CARGO_LOCKED: ${{ env.IS_RELEASE_BRANCH && '--locked' || '' }}
 
 jobs:
   # see: https://github.com/orgs/community/discussions/26822
@@ -96,11 +98,11 @@ jobs:
           toolchain-version: ${{ env.RISC0_TOOLCHAIN_VERSION }}
           features: ${{ matrix.feature }}
       - name: cargo clippy risc0-ethereum
-        run: cargo clippy --workspace --all-targets --all-features
+        run: cargo clippy $CARGO_LOCKED --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
           RISC0_SKIP_BUILD: true
-      - name: cargo clippy all examples
+      - name: cargo clippy $CARGO_LOCKED all examples
         run: ../.github/scripts/cargo-clippy.sh
         working-directory: examples
         env:
@@ -145,9 +147,9 @@ jobs:
           features: ${{ matrix.feature }}
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
       - name: cargo build
-        run: cargo build --workspace --all-features
+        run: cargo build $CARGO_LOCKED --workspace --all-features
       - name: cargo test
-        run: cargo test --workspace --all-features --timings
+        run: cargo test $CARGO_LOCKED --workspace --all-features --timings
       - name: Upload timings artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -205,7 +207,7 @@ jobs:
           submodules: recursive
       - uses: risc0/risc0/.github/actions/rustup@main
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
-      - run: cargo doc --all-features --no-deps --workspace
+      - run: cargo doc $CARGO_LOCKED --all-features --no-deps --workspace
       - run: forge doc
 
   # Run as a separate job because we need to install a different set of tools.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_TOOLCHAIN_VERSION: r0.1.81.0
   RISC0_MONOREPO_REF: "main"
-  IS_RELEASE_BRANCH: ${{ startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'refs/heads/release-') }}
-  CARGO_LOCKED: ${{ fromJson(toJson(env.IS_RELEASE_BRANCH && '--locked' || '')) }}
+  CARGO_LOCKED:  ${{ (startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'refs/heads/release-')) && '--locked' || '' }}
 
 jobs:
   # see: https://github.com/orgs/community/discussions/26822

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_TOOLCHAIN_VERSION: r0.1.81.0
   RISC0_MONOREPO_REF: "main"
+  # CARGO_LOCKED is defined as the string '--locked' in PRs targeting release branches and '' elsewhere.
   CARGO_LOCKED:  ${{ (startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'refs/heads/release-')) && '--locked' || '' }}
 
 jobs:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,6 @@
      * Update `risc0` crate dependencies. In all workspaces:
          >  You can find the workspaces with `grep -R '\[workspace\]' --include Cargo.toml -l .`
          * Change the reference for `risc0` crates (e.g. `risc0-zkvm`, `bonsai-sdk`) to the latest monorepo release.
-         <!-- TODO: Add --locked to checks in CI against the release branch, such that it guarantees the checked in lock files are complete and consistent -->
          * Run `cargo update`.
      * Remove `Cargo.lock` from `.gitignore` and commit all lock files.
 


### PR DESCRIPTION
I tested this PR by opening https://github.com/risc0/risc0-ethereum/pull/342. Looking at https://github.com/risc0/risc0-ethereum/pull/342/checks, we expect the CI jobs to fail.