### PR TITLE
WEB3-243: Upgrade Artifacts Actions using `@v3` to `@v4`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --all-features --timings
       - name: Upload timings artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}
           path: target/cargo-timings/


### PR DESCRIPTION
- Artifacts actions `@v3` being deprecated.
- All `actions/upload-artifact` and `actions/download-artifact` uses must be upgraded to `@v4` before brownout dates in January:
  - https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

<img src="https://github.com/user-attachments/assets/e1f86962-652f-46ac-a35d-2a9eb7c1db34" width="400"/>
