### PR TITLE
WEB3-245: Use --locked to build cargo-risczero from main in CI

### DIFF
--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -28,11 +28,11 @@ runs:
           ref: ${{ inputs.ref }}
           lfs: true
       - name: install cargo-risczero
-        run: cargo install --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
+        run: cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
         working-directory: tmp/risc0
         shell: bash
       - name: install r0vm
-        run: cargo install --bin r0vm --path risc0/cargo-risczero --features "${{ inputs.features }}"
+        run: cargo install --locked --bin r0vm --path risc0/cargo-risczero --features "${{ inputs.features }}"
         shell: bash
         working-directory: tmp/risc0
       - name: install toolchains

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
       - name: Start local Ethereum testnet
         run: |
-          kurtosis --enclave local-eth-testnet run github.com/ethpandaops/ethereum-package@v4.4.0
+          kurtosis --enclave local-eth-testnet run github.com/ethpandaops/ethereum-package@4.4.0
           echo "ETH_TESTNET_EL_URL=http://$(kurtosis port print local-eth-testnet el-1-geth-lighthouse rpc)" >> $GITHUB_ENV
           echo "ETH_TESTNET_CL_URL=$(kurtosis port print local-eth-testnet cl-1-lighthouse-geth http)" >> $GITHUB_ENV
       - name: Wait for the local Ethereum testnet to come up

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
       - name: Start local Ethereum testnet
         run: |
-          kurtosis --enclave local-eth-testnet run github.com/ethpandaops/ethereum-package@2e9e5a41784f792a206f1a108c2c96830b2c95ef
+          kurtosis --enclave local-eth-testnet run github.com/ethpandaops/ethereum-package@v4.4.0
           echo "ETH_TESTNET_EL_URL=http://$(kurtosis port print local-eth-testnet el-1-geth-lighthouse rpc)" >> $GITHUB_ENV
           echo "ETH_TESTNET_CL_URL=$(kurtosis port print local-eth-testnet cl-1-lighthouse-geth http)" >> $GITHUB_ENV
       - name: Wait for the local Ethereum testnet to come up

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: risc0/risc0/.github/actions/sccache@main
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
-      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+      - uses: foundry-rs/foundry-toolchain@v1
       - uses: ./.github/actions/cargo-risczero-install
         with:
           ref: ${{ env.RISC0_MONOREPO_REF }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: cargo check examples
         run: ../.github/scripts/cargo-check.sh
         working-directory: examples
-      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+      - uses: foundry-rs/foundry-toolchain@v1
       - name: forge check risc0-ethereum
         run: forge fmt --check
         working-directory: contracts
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ env.RISC0_MONOREPO_REF }}
           toolchain-version: ${{ env.RISC0_TOOLCHAIN_VERSION }}
           features: ${{ matrix.feature }}
-      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+      - uses: foundry-rs/foundry-toolchain@v1
       - name: cargo build
         run: cargo build $CARGO_LOCKED --workspace --all-features
       - name: cargo test
@@ -188,7 +188,7 @@ jobs:
           ref: ${{ env.RISC0_MONOREPO_REF }}
           toolchain-version: ${{ env.RISC0_TOOLCHAIN_VERSION }}
           features: ${{ matrix.feature }}
-      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+      - uses: foundry-rs/foundry-toolchain@v1
       - name: cargo test all examples
         run: ../.github/scripts/cargo-test.sh
         working-directory: examples
@@ -206,7 +206,7 @@ jobs:
         with:
           submodules: recursive
       - uses: risc0/risc0/.github/actions/rustup@main
-      - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+      - uses: foundry-rs/foundry-toolchain@v1
       - run: cargo doc $CARGO_LOCKED --all-features --no-deps --workspace
       - run: forge doc
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,12 +102,14 @@ jobs:
         env:
           RUSTFLAGS: -Dwarnings
           RISC0_SKIP_BUILD: true
+          RISC0_SKIP_BUILD_KERNEL: true,
       - name: cargo clippy $CARGO_LOCKED all examples
         run: ../.github/scripts/cargo-clippy.sh
         working-directory: examples
         env:
           RUSTFLAGS: -Dwarnings
           RISC0_SKIP_BUILD: true
+          RISC0_SKIP_BUILD_KERNEL: true,
       - run: sccache --show-stats
 
   test-risc0-ethereum:
@@ -208,6 +210,9 @@ jobs:
       - uses: risc0/risc0/.github/actions/rustup@main
       - uses: foundry-rs/foundry-toolchain@v1
       - run: cargo doc $CARGO_LOCKED --all-features --no-deps --workspace
+        env:
+          RISC0_SKIP_BUILD: true,
+          RISC0_SKIP_BUILD_KERNEL: true,
       - run: forge doc
 
   # Run as a separate job because we need to install a different set of tools.


### PR DESCRIPTION
I started seeing the following errors in our CI, and realized that we do not apply `--locked` when building `cargo-risczero` from `main`. This would be good to help with stability of CI.
https://github.com/risc0/risc0-ethereum/actions/runs/12078623988/job/33683295704?pr=346
