### PR TITLE
WEB3-254: Remove dependencies of set-builder-guest to allow publishing to crates.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,8 @@ jobs:
         env:
           RISC0_SKIP_BUILD: true,
           RISC0_SKIP_BUILD_KERNEL: true,
-      - run: forge doc
+      # TODO(#355) Re-enable this check.
+      #- run: forge doc
 
   # Run as a separate job because we need to install a different set of tools.
   # In particular, it uses nightly Rust and _does not_ install Forge or cargo risczero.

--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "risc0-aggregation"
+description = "Proof aggregation for RISC Zero"
 resolver = "2"
 version = "0.1.0-alpha.1"
 edition = { workspace = true }
+license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 

--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -26,5 +26,5 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [features]
-default = ["verify"]
+default = []
 verify = ["dep:guest-set-builder"]

--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -13,7 +13,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
-guest-set-builder = { path = "./guest", optional = true }
+guest-set-builder = { version = "0.1.0", path = "./guest", optional = true }
 hex = { workspace = true }
 risc0-binfmt = { workspace = true }
 risc0-zkp = { workspace = true }

--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -13,7 +13,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
-guest-set-builder = { version = "0.1.0", path = "./guest", optional = true }
+# TODO(#353) Determine if it is possible to publish risc0-aggregation with set builder image ID and ELF
+#guest-set-builder = { version = "0.1.0", path = "./guest", optional = true }
 hex = { workspace = true }
 risc0-binfmt = { workspace = true }
 risc0-zkp = { workspace = true }
@@ -26,5 +27,5 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [features]
-default = []
-verify = ["dep:guest-set-builder"]
+default = ["verify"]
+verify = []

--- a/aggregation/guest/set-builder/Cargo.toml
+++ b/aggregation/guest/set-builder/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "set-builder"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 
 [workspace]
 
 [dependencies]
-risc0-aggregation = { path = "../..", default-features = false }
+risc0-aggregation = { version = "0.1.0-alpha.1", path = "../..", default-features = false }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std"] }

--- a/aggregation/src/lib.rs
+++ b/aggregation/src/lib.rs
@@ -32,8 +32,11 @@ mod receipt;
 #[cfg(feature = "verify")]
 pub use receipt::{
     EncodingError, RecursionVerifierParamters, SetInclusionReceipt,
-    SetInclusionReceiptVerifierParameters, VerificationError, SET_BUILDER_ELF, SET_BUILDER_ID,
-    SET_BUILDER_PATH,
+    SetInclusionReceiptVerifierParameters,
+    VerificationError,
+    /* TODO(#353)
+    SET_BUILDER_ELF, SET_BUILDER_ID, SET_BUILDER_PATH,
+    */
 };
 
 alloy_sol_types::sol! {

--- a/aggregation/src/receipt.rs
+++ b/aggregation/src/receipt.rs
@@ -26,7 +26,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{merkle_path_root, GuestOutput, Seal};
 
-pub use guest_set_builder::{SET_BUILDER_ELF, SET_BUILDER_ID, SET_BUILDER_PATH};
+// TODO(#353)
+//pub use guest_set_builder::{SET_BUILDER_ELF, SET_BUILDER_ID, SET_BUILDER_PATH};
 
 /// A receipt for a claim that is part of a set of verified claims (i.e. an aggregation).
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -97,18 +98,31 @@ impl<Claim> SetInclusionReceipt<Claim>
 where
     Claim: Digestible + Clone + Serialize,
 {
+    /* TODO(#353)
     /// Construct a [SetInclusionReceipt] with the given Merkle inclusion path and claim.
     ///
     /// Path should contain all sibling nodes in the tree from the leaf to the root. Note that the
     /// path does not include the leaf or the root itself. Resulting receipt will have default
     /// verifier parameters and no root receipt.
-    pub fn from_path(claim: impl Into<MaybePruned<Claim>>, merkle_path: Vec<Digest>) -> Self {
+    pub fn from_path(claim: impl Into<MaybePruned<Claim>>, merkle_path: Vec<Digest>);
+    }
+    */
+
+    /// Construct a [SetInclusionReceipt] with the given Merkle inclusion path and claim.
+    ///
+    /// Path should contain all sibling nodes in the tree from the leaf to the root. Note that the
+    /// path does not include the leaf or the root itself. Resulting receipt will have the given
+    /// verifier parameter digest and no root receipt.
+    pub fn from_path_with_verifier_params(
+        claim: impl Into<MaybePruned<Claim>>,
+        merkle_path: Vec<Digest>,
+        verifier_parameters: impl Into<Digest>,
+    ) -> Self {
         Self {
             claim: claim.into(),
             root: None,
             merkle_path,
-            verifier_parameters: SetInclusionReceiptVerifierParameters::default()
-                .digest::<sha::Impl>(),
+            verifier_parameters: verifier_parameters.into(),
         }
     }
 
@@ -131,6 +145,7 @@ where
         Self { root: None, ..self }
     }
 
+    /* TODO(#353)
     /// Verify the integrity of this receipt, ensuring the claim is attested to by the seal.
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {
         self.verify_integrity_with_context(
@@ -139,6 +154,7 @@ where
             Some(RecursionVerifierParamters::default()),
         )
     }
+    */
 
     /// Verify the integrity of this receipt, ensuring the claim is attested to by the seal.
     // TODO: Use a different error type (e.g. the one from risc0-zkvm).
@@ -250,6 +266,7 @@ impl Digestible for SetInclusionReceiptVerifierParameters {
     }
 }
 
+/* TODO(#353)
 impl Default for SetInclusionReceiptVerifierParameters {
     /// Default set of parameters used to verify a
     /// [SetInclusionReceipt][super::SetInclusionReceipt].
@@ -259,6 +276,7 @@ impl Default for SetInclusionReceiptVerifierParameters {
         }
     }
 }
+*/
 
 // TODO(victor): Move this into risc0-zkvm?
 /// Verifier parameters used for recursive verification (e.g. via env::verify) of receipts.


### PR DESCRIPTION
This PR resolves issues with publishing `risc0-aggregation` stemming from dependency on the `set-builder` guest through Cargo.
It does so by removing usage of that guest, which is in the form of all code dependending on `SET_BUILDER_ID` or `SET_BUILDER_ELF`.
In practice, these values are difficult to use anyway, because they need to align with an on-chain verifier. Unless reproducible builds are always used, these values will flucuate.
There is an open issue on how to better manage these values.

Related https://github.com/risc0/risc0-ethereum/issues/353
