### PR TITLE
Chery-pick: Remove dependencies of set-builder-guest to allow publishing to crates.io (#354)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,8 @@ jobs:
         env:
           RISC0_SKIP_BUILD: true,
           RISC0_SKIP_BUILD_KERNEL: true,
-      - run: forge doc
+      # TODO(#355) Re-enable this check.
+      #- run: forge doc
 
   # Run as a separate job because we need to install a different set of tools.
   # In particular, it uses nightly Rust and _does not_ install Forge or cargo risczero.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "guest-set-builder"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "risc0-build",
  "risc0-build-ethereum",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-aggregation"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.8.14",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,6 @@ version = "0.1.0-rc.1"
 dependencies = [
  "alloy-primitives 0.8.14",
  "alloy-sol-types",
- "guest-set-builder",
  "hex",
  "rand",
  "risc0-binfmt",

--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "risc0-aggregation"
+description = "Proof aggregation for RISC Zero"
 resolver = "2"
 version = "0.1.0-rc.1"
 edition = { workspace = true }
+license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
@@ -13,7 +15,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
-guest-set-builder = { path = "./guest", optional = true }
+# TODO(#353) Determine if it is possible to publish risc0-aggregation with set builder image ID and ELF
+#guest-set-builder = { version = "0.1.0", path = "./guest", optional = true }
 hex = { workspace = true }
 risc0-binfmt = { workspace = true }
 risc0-zkp = { workspace = true }
@@ -27,4 +30,4 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [features]
 default = ["verify"]
-verify = ["dep:guest-set-builder"]
+verify = []

--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -2,7 +2,7 @@
 name = "risc0-aggregation"
 description = "Proof aggregation for RISC Zero"
 resolver = "2"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/aggregation/guest/Cargo.toml
+++ b/aggregation/guest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "guest-set-builder"
 resolver = "2"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/aggregation/guest/set-builder/Cargo.lock
+++ b/aggregation/guest/set-builder/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-aggregation"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/aggregation/guest/set-builder/Cargo.toml
+++ b/aggregation/guest/set-builder/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-aggregation = { path = "../..", default-features = false }
+risc0-aggregation = { version = "0.1.0", path = "../..", default-features = false }
 risc0-zkvm = { version = "1.2.0", default-features = false, features = ["std"] }

--- a/aggregation/src/lib.rs
+++ b/aggregation/src/lib.rs
@@ -32,8 +32,11 @@ mod receipt;
 #[cfg(feature = "verify")]
 pub use receipt::{
     EncodingError, RecursionVerifierParamters, SetInclusionReceipt,
-    SetInclusionReceiptVerifierParameters, VerificationError, SET_BUILDER_ELF, SET_BUILDER_ID,
-    SET_BUILDER_PATH,
+    SetInclusionReceiptVerifierParameters,
+    VerificationError,
+    /* TODO(#353)
+    SET_BUILDER_ELF, SET_BUILDER_ID, SET_BUILDER_PATH,
+    */
 };
 
 alloy_sol_types::sol! {

--- a/aggregation/src/receipt.rs
+++ b/aggregation/src/receipt.rs
@@ -26,7 +26,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{merkle_path_root, GuestOutput, Seal};
 
-pub use guest_set_builder::{SET_BUILDER_ELF, SET_BUILDER_ID, SET_BUILDER_PATH};
+// TODO(#353)
+//pub use guest_set_builder::{SET_BUILDER_ELF, SET_BUILDER_ID, SET_BUILDER_PATH};
 
 /// A receipt for a claim that is part of a set of verified claims (i.e. an aggregation).
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -97,18 +98,31 @@ impl<Claim> SetInclusionReceipt<Claim>
 where
     Claim: Digestible + Clone + Serialize,
 {
+    /* TODO(#353)
     /// Construct a [SetInclusionReceipt] with the given Merkle inclusion path and claim.
     ///
     /// Path should contain all sibling nodes in the tree from the leaf to the root. Note that the
     /// path does not include the leaf or the root itself. Resulting receipt will have default
     /// verifier parameters and no root receipt.
-    pub fn from_path(claim: impl Into<MaybePruned<Claim>>, merkle_path: Vec<Digest>) -> Self {
+    pub fn from_path(claim: impl Into<MaybePruned<Claim>>, merkle_path: Vec<Digest>);
+    }
+    */
+
+    /// Construct a [SetInclusionReceipt] with the given Merkle inclusion path and claim.
+    ///
+    /// Path should contain all sibling nodes in the tree from the leaf to the root. Note that the
+    /// path does not include the leaf or the root itself. Resulting receipt will have the given
+    /// verifier parameter digest and no root receipt.
+    pub fn from_path_with_verifier_params(
+        claim: impl Into<MaybePruned<Claim>>,
+        merkle_path: Vec<Digest>,
+        verifier_parameters: impl Into<Digest>,
+    ) -> Self {
         Self {
             claim: claim.into(),
             root: None,
             merkle_path,
-            verifier_parameters: SetInclusionReceiptVerifierParameters::default()
-                .digest::<sha::Impl>(),
+            verifier_parameters: verifier_parameters.into(),
         }
     }
 
@@ -131,6 +145,7 @@ where
         Self { root: None, ..self }
     }
 
+    /* TODO(#353)
     /// Verify the integrity of this receipt, ensuring the claim is attested to by the seal.
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {
         self.verify_integrity_with_context(
@@ -139,6 +154,7 @@ where
             Some(RecursionVerifierParamters::default()),
         )
     }
+    */
 
     /// Verify the integrity of this receipt, ensuring the claim is attested to by the seal.
     // TODO: Use a different error type (e.g. the one from risc0-zkvm).
@@ -250,6 +266,7 @@ impl Digestible for SetInclusionReceiptVerifierParameters {
     }
 }
 
+/* TODO(#353)
 impl Default for SetInclusionReceiptVerifierParameters {
     /// Default set of parameters used to verify a
     /// [SetInclusionReceipt][super::SetInclusionReceipt].
@@ -259,6 +276,7 @@ impl Default for SetInclusionReceiptVerifierParameters {
         }
     }
 }
+*/
 
 // TODO(victor): Move this into risc0-zkvm?
 /// Verifier parameters used for recursive verification (e.g. via env::verify) of receipts.


### PR DESCRIPTION
This PR resolves issues with publishing `risc0-aggregation` stemming
from dependency on the `set-builder` guest through Cargo.
It does so by removing usage of that guest, which is in the form of all
code dependending on `SET_BUILDER_ID` or `SET_BUILDER_ELF`.
In practice, these values are difficult to use anyway, because they need
to align with an on-chain verifier. Unless reproducible builds are
always used, these values will flucuate.
There is an open issue on how to better manage these values.

Related https://github.com/risc0/risc0-ethereum/issues/353
