### PR TITLE
WEB3-261: Index root in VerifiedRoot

### DIFF
--- a/contracts/src/IRiscZeroSetVerifier.sol
+++ b/contracts/src/IRiscZeroSetVerifier.sol
@@ -30,7 +30,7 @@ interface IRiscZeroSetVerifier is IRiscZeroVerifier {
     error VerificationFailed();
 
     /// A new root has been added to the set.
-    event VerifiedRoot(bytes32 root);
+    event VerifiedRoot(bytes32 indexed root);
 
     /// Publishes a new root of a proof aggregation.
     function submitMerkleRoot(bytes32 root, bytes calldata seal) external;

--- a/contracts/src/IRiscZeroSetVerifier.sol
+++ b/contracts/src/IRiscZeroSetVerifier.sol
@@ -30,7 +30,7 @@ interface IRiscZeroSetVerifier is IRiscZeroVerifier {
     error VerificationFailed();
 
     /// A new root has been added to the set.
-    event VerifiedRoot(bytes32 indexed root);
+    event VerifiedRoot(bytes32 indexed root, bytes seal);
 
     /// Publishes a new root of a proof aggregation.
     function submitMerkleRoot(bytes32 root, bytes calldata seal) external;

--- a/contracts/src/RiscZeroSetVerifier.sol
+++ b/contracts/src/RiscZeroSetVerifier.sol
@@ -121,7 +121,7 @@ contract RiscZeroSetVerifier is IRiscZeroSetVerifier {
         VERIFIER.verify(seal, IMAGE_ID, sha256(abi.encode(IMAGE_ID, root)));
         merkleRoots[root] = true;
 
-        emit VerifiedRoot(root);
+        emit VerifiedRoot(root, seal);
     }
 
     function containsRoot(bytes32 root) external view returns (bool) {

--- a/contracts/test/RiscZeroSetVerifier.t.sol
+++ b/contracts/test/RiscZeroSetVerifier.t.sol
@@ -41,9 +41,10 @@ contract RiscZeroSetVerifierTest is Test {
     }
 
     function submitRoot(bytes32 root) internal {
+        bytes memory seal = mockProveRoot(root).seal;
         vm.expectEmit(true, true, true, true);
-        emit IRiscZeroSetVerifier.VerifiedRoot(root);
-        setVerifier.submitMerkleRoot(root, mockProveRoot(root).seal);
+        emit IRiscZeroSetVerifier.VerifiedRoot(root, seal);
+        setVerifier.submitMerkleRoot(root, seal);
         require(setVerifier.containsRoot(root), "set verifier does not contain submitted root");
     }
 


### PR DESCRIPTION
It seems that only the parameters marked with indexed become topics that we can filter on. Non-indexed parameters are encoded as part of the data payload of the log entry and cannot be used for filtering.
It also adds the seal as part of the event as unfortunately, in cases where the event gets triggered by an internal transaction, for instance when using `submitRootAndFulfillBatch` the call data of the method is not available from the original transaction