### PR TITLE
fix: typos in documentation files

### DIFF
--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -478,7 +478,7 @@ timelock-delay = 1
 router = "0x27983ee173aD10E171D17C9c5C14d5baFE997609"
 
 # NOTE: As of the 1.1.0-rc.2 deployment on August 21, Forge could not verify the contracts.
-# Apperent issue is that because Linea Sepolia is not in the list of chains named in alloy-chains, Forge doesn't know its Etherscan API URL.
+# Apparent issue is that because Linea Sepolia is not in the list of chains named in alloy-chains, Forge doesn't know its Etherscan API URL.
 
 # NOTE: As of the 1.1.0-rc.3 Deployment on August 29, Fireblocks does not support sending transactions to Linea Sepolia.
 # As a result, the router is deployed, but it is empty and useless.

--- a/contracts/src/RiscZeroVerifierRouter.sol
+++ b/contracts/src/RiscZeroVerifierRouter.sol
@@ -70,7 +70,7 @@ contract RiscZeroVerifierRouter is IRiscZeroVerifier, Ownable2Step {
         verifiers[selector] = TOMBSTONE;
     }
 
-    /// @notice Get the associatied verifier, reverting if the selector is unknown or removed.
+    /// @notice Get the associated verifier, reverting if the selector is unknown or removed.
     function getVerifier(bytes4 selector) public view returns (IRiscZeroVerifier) {
         IRiscZeroVerifier verifier = verifiers[selector];
         if (verifier == UNSET) {
@@ -82,7 +82,7 @@ contract RiscZeroVerifierRouter is IRiscZeroVerifier, Ownable2Step {
         return verifier;
     }
 
-    /// @notice Get the associatied verifier, reverting if the selector is unknown or removed.
+    /// @notice Get the associated verifier, reverting if the selector is unknown or removed.
     function getVerifier(bytes calldata seal) public view returns (IRiscZeroVerifier) {
         // Use the first 4 bytes of the seal at the selector to look up in the mapping.
         return getVerifier(bytes4(seal[0:4]));


### PR DESCRIPTION
Corrected `Apperent` to `Apparent`
Corrected `associatied` to `associated` x2.