### PR TITLE
WEB3-294: Update deployment.toml to mark 1.2 mainnet verifiers as routable

### DIFF
--- a/contracts/deployment-test/Deployment.t.sol
+++ b/contracts/deployment-test/Deployment.t.sol
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -33,7 +33,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0xAC292cF957Dd5BA174cdA13b05C16aFC71700327"
 estop = "0x03B66cEDaB014Ca7E970Bfb83C1951d10DD2A805"
-unroutable = true # remove when added to the router
 
 ###
 
@@ -156,7 +155,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0xAC292cF957Dd5BA174cdA13b05C16aFC71700327"
 estop = "0x03B66cEDaB014Ca7E970Bfb83C1951d10DD2A805"
-unroutable = true # remove when added to the router
 
 ###
 
@@ -232,7 +230,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0x8062Dc6C824F10e62E47FdC55A0ecD54C2641F2d"
 estop = "0x5b188d3d31f7bcfC2e3A22F85c3ca4dD23a77dD1"
-unroutable = true # remove when added to the router
 
 ###
 
@@ -307,7 +304,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0xAC292cF957Dd5BA174cdA13b05C16aFC71700327"
 estop = "0x03B66cEDaB014Ca7E970Bfb83C1951d10DD2A805"
-unroutable = true # remove when added to the router
 
 ###
 
@@ -382,7 +378,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0xAC292cF957Dd5BA174cdA13b05C16aFC71700327"
 estop = "0x03B66cEDaB014Ca7E970Bfb83C1951d10DD2A805"
-unroutable = true # remove when added to the router
 
 ###
 
@@ -460,7 +455,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0x8C8b557C6EBDA8E6D62E7b54B7B5Ed8cFa8B48B4"
 estop = "0x6Fb722974D67A55091c70129Bd0Bb06ec025ce5D"
-unroutable = true # remove when added to the router
 
 ###
 
@@ -545,7 +539,6 @@ version = "1.2.0"
 selector = "0xc101b42b"
 verifier = "0x8062Dc6C824F10e62E47FdC55A0ecD54C2641F2d"
 estop = "0x5b188d3d31f7bcfC2e3A22F85c3ca4dD23a77dD1"
-unroutable = true # remove when added to the router
 
 ###
 

--- a/contracts/script/Manage.s.sol
+++ b/contracts/script/Manage.s.sol
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Timelock controller execute transactions have now cleared, and so the 1.2 verifiers are live on mainnets.