### PR TITLE
Fix redundant inheritance in `VoteToken.sol`: remove `Nonces`

### DIFF
--- a/examples/governance/contracts/src/VoteToken.sol
+++ b/examples/governance/contracts/src/VoteToken.sol
@@ -33,7 +33,7 @@ contract VoteToken is ERC20, Ownable, ERC20Permit, ERC20Votes {
         super._update(from, to, value);
     }
 
-    function nonces(address owner) public view override(Nonces, ERC20Permit) returns (uint256) {
+    function nonces(address owner) public view override(ERC20Permit) returns (uint256) {
         return super.nonces(owner);
     }
 }


### PR DESCRIPTION
**Description:**
This pull request simplifies the `nonces` function in the `VoteToken` contract by removing the redundant inheritance of `Nonces`. The `ERC20Permit` contract already includes the `nonces` method, making `Nonces` unnecessary.

**Changes:**
Updated the `nonces` function signature to inherit solely from `ERC20Permit`.
Improved readability and reduced potential confusion caused by redundant types.

This update ensures the contract remains clean and aligns with Solidity best practices.