### PR TITLE
WEB3-275: switch nybbles to use re-exported type from alloy-trie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ op-alloy-network = { version = "0.8" }
 
 # Alloy host dependencies
 alloy = { version = "0.8" }
-alloy-trie = { version = "0.7" }
+# Note: semver breaking change in 0.7.7, be careful if switching to lower patch version
+alloy-trie = { version = "0.7.7" }
 
 # Beacon chain support
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus.git", rev = "cf3c404043230559660810bc0c9d6d5a8498d819" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ anyhow = { version = "1.0" }
 bincode = { version = "1.3" }
 clap = { version = "4.5", features = ["derive", "env"] }
 log = "0.4"
-nybbles = { version = "0.2" }
 revm = { version = "18.0", default-features = false, features = ["std"] }
 reqwest = "0.12"
 serde = "1.0"

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -18,11 +18,10 @@ alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-rlp = { workspace = true }
 alloy-sol-types = { workspace = true }
-alloy-trie = { workspace = true }
+alloy-trie = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
 ethereum-consensus = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
-nybbles = { workspace = true, features = ["serde"] }
 reqwest = { workspace = true, optional = true }
 revm = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/steel/src/mpt.rs
+++ b/steel/src/mpt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/mpt.rs
+++ b/steel/src/mpt.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 use alloy_primitives::{b256, keccak256, map::B256HashMap, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, PayloadView, EMPTY_STRING_CODE};
 use alloy_trie::nodes::encode_path_leaf;
-use nybbles::Nibbles;
+use alloy_trie::Nibbles;
 use serde::{Deserialize, Serialize};
 
 /// Root hash of an empty Merkle Patricia trie, i.e. `keccak256(RLP(""))`.


### PR DESCRIPTION
Using re-exported to avoid issues if they make semver breaking changes in future.

Also increased the minimum patch version to be safe, but opinionated if this should be removed or only applied to `steel` as the minimum patch might break in edge case usages. Happy to revert this