### PR TITLE
WEB3-281: update create-steel-app to 1.2

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -21,7 +21,6 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use risc0_build::GuestListEntry;
-use risc0_zkp::core::digest::Digest;
 
 const SOL_HEADER: &str = r#"// Copyright 2024 RISC Zero, Inc.
 //

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -109,7 +109,7 @@ pub fn generate_image_id_sol(guests: &[GuestListEntry]) -> Result<Vec<u8>> {
         .iter()
         .map(|guest| {
             let name = guest.name.to_uppercase().replace('-', "_");
-            let image_id = hex::encode(Digest::from(guest.image_id));
+            let image_id = hex::encode(guest.image_id);
             format!("bytes32 public constant {name}_ID = bytes32(0x{image_id});")
         })
         .collect();

--- a/examples/erc20-counter/apps/src/bin/publisher.rs
+++ b/examples/erc20-counter/apps/src/bin/publisher.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/token-stats/host/src/main.rs
+++ b/examples/token-stats/host/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/token-stats/methods/guest/src/main.rs
+++ b/examples/token-stats/methods/guest/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/docs/create-steel-app/README.md
+++ b/steel/docs/create-steel-app/README.md
@@ -12,13 +12,13 @@ Make sure to have the following installed:
 2. [Foundry]
 3. [cargo-risczero]
 
+N.B. Please make sure to run `foundryup` to update to the latest Foundry version before continuing. 
+
 ## Usage
 
 ```sh
 sh <(curl -fsSL https://raw.githubusercontent.com/risc0/risc0-ethereum/refs/heads/main/steel/docs/create-steel-app/create-steel-app)
 ```
-
-The script will automatically detect your current `cargo-risczero` version and use that for the corresponding version of the `erc20-counter` example. You also have the manual choice between two release versions: [1.0] and [1.1].
 
 Once the script is finished running, you should:
 

--- a/steel/docs/create-steel-app/create-steel-app
+++ b/steel/docs/create-steel-app/create-steel-app
@@ -26,10 +26,10 @@ get_risc0_version() {
     echo "detected risc0 version: ${RISC0_VERSION:?}"
 
     # map version to branch
-    if [[ "${RISC0_VERSION:?}" =~ ^1\.1\. ]]; then
-        BRANCH="release-1.1"
+    if [[ "${RISC0_VERSION:?}" =~ ^1\.2\. ]]; then
+        BRANCH="release-1.2"
     else
-        echo "unsupported risc0 version. version 1.1 is supported"
+        echo "unsupported risc0 version. version 1.2 is supported"
         BRANCH=""
     fi
 }
@@ -37,9 +37,9 @@ get_risc0_version() {
 select_branch() {
     get_risc0_version
     
-    # NOTE: Only 1.1 is currently supported.
+    # NOTE: Only 1.2 is currently supported.
 
-    BRANCH="release-1.1"
+    BRANCH="release-1.2"
     echo "selected branch: ${BRANCH:?}"
 
     # Logic below can be used when more than one version is supported.

--- a/steel/src/block.rs
+++ b/steel/src/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/history/mod.rs
+++ b/steel/src/history/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/host/db/mod.rs
+++ b/steel/src/host/db/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/host/db/proof.rs
+++ b/steel/src/host/db/proof.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/host/mod.rs
+++ b/steel/src/host/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/steel/src/state.rs
+++ b/steel/src/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
* updated create-steel-app to use 1.2 by default
* also added a line to the README to make sure that Foudry is updated to avoid a relatively old bug (most end users should be fine, but I ran into this issue)