### PR TITLE
WEB3-333: fix: `unstable-history` doctest

### DIFF
--- a/crates/steel/src/host/builder.rs
+++ b/crates/steel/src/host/builder.rs
@@ -250,13 +250,13 @@ impl<P> EvmEnvBuilder<P, EthBlockHeader, Url> {
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() -> anyhow::Result<()> {
     /// let commitment_hash = B256::from_str("0x1234...")?;
-    /// let env = EthEvmEnv::builder()
+    /// let builder = EthEvmEnv::builder()
     ///     .rpc(Url::parse("https://ethereum-rpc.publicnode.com")?)
     ///     .beacon_api(Url::parse("https://ethereum-beacon-api.publicnode.com")?)
     ///     .block_number(1_000_000);  // execute against historical state
     /// # #[cfg(feature = "unstable-history")] // required because of the stability crate
-    /// let env = env.commitment_block_hash(commitment_hash); // commit to recent block
-    /// env.build().await?;
+    /// let builder = builder.commitment_block_hash(commitment_hash); // commit to recent block
+    /// let env = builder.build().await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/steel/src/host/builder.rs
+++ b/crates/steel/src/host/builder.rs
@@ -253,10 +253,10 @@ impl<P> EvmEnvBuilder<P, EthBlockHeader, Url> {
     /// let env = EthEvmEnv::builder()
     ///     .rpc(Url::parse("https://ethereum-rpc.publicnode.com")?)
     ///     .beacon_api(Url::parse("https://ethereum-beacon-api.publicnode.com")?)
-    ///     .block_number(1_000_000) // execute against historical state
-    ///     .commitment_block_hash(commitment_hash) // commit to recent block
-    ///     .build()
-    ///     .await?;
+    ///     .block_number(1_000_000);  // execute against historical state
+    /// # #[cfg(feature = "unstable-history")] // required because of the stability crate
+    /// let env = env.commitment_block_hash(commitment_hash); // commit to recent block
+    /// env.build().await?;
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
The doctest gets included even though the corresponding method is behind a feature using `#[stability::unstable(feature = "history")]`. This leads to failing tests if the `unstable-history` feature is not enabled.
Fixed by adding a hidden `#[cfg(feature = "unstable-history")]` to the example, in the docs it still looks like the following:
```rust
let commitment_hash = B256::from_str("0x1234...")?;
let builder = EthEvmEnv::builder()
    .rpc(Url::parse("https:// ethereum-rpc. publicnode. com")?)
    .beacon_api(Url::parse("https:// ethereum-beacon-api. publicnode. com")?)
    .block_number(1_000_000);  // execute against historical state
let builder = builder.commitment_block_hash(commitment_hash); // commit to recent block
let env = builder.build().await?;
```