### PR TITLE
WEB3-361: chore: Remove `munge` dependency

### DIFF
--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -41,7 +41,6 @@ alloy-trie = { workspace = true }
 arrayvec = { workspace = true }
 bincode = { workspace = true, optional = true }
 itertools = { workspace = true }
-munge = { version = "=0.4.1", optional = true }
 rkyv = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -57,7 +56,7 @@ harness = false
 
 [features]
 default = []
-rkyv = ["dep:munge", "dep:rkyv"]
+rkyv = ["dep:rkyv"]
 serde = ["dep:serde", "dep:bincode", "alloy-primitives/serde", "alloy-trie/serde"]
 rlp_serialize = []
 orphan = []


### PR DESCRIPTION
The recently released 0.4.3 of `munge` fixes issues with the previous 0.4.2, so the additional locked dependency is no longer needed.