### PR TITLE
WEB3-362: chore: Run actions requiring secrets not from forks

### DIFF
--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -51,10 +51,14 @@ runs:
         path: 'tmp/risc0'
         ref: ${{ inputs.ref }}
         lfs: true
-    - name: install Rust toolchain
+    - name: set up Rust
       if: inputs.ref != ''
       uses: risc0/risc0/.github/actions/rustup@main
+    - name: install risc0 toolchain
+      if: inputs.ref != ''
+      run: rustup update # This will detect and install the required toolchain
       working-directory: tmp/risc0
+      shell: bash
     - name: install cargo-risczero from git
       if: inputs.ref != ''
       run: cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -51,17 +51,12 @@ runs:
         path: 'tmp/risc0'
         ref: ${{ inputs.ref }}
         lfs: true
-    - name: set up Rust
-      if: inputs.ref != ''
-      uses: risc0/risc0/.github/actions/rustup@main
-    - name: install risc0 toolchain
-      if: inputs.ref != ''
-      run: rustup update # This will detect and install the required toolchain
-      working-directory: tmp/risc0
-      shell: bash
     - name: install cargo-risczero from git
       if: inputs.ref != ''
-      run: cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
+      # Use cargo build first, which should detect and download the correct Rust toolchain
+      run: |
+        cargo build --release --locked -p cargo-risczero --no-default-features --features "${{ inputs.features }}"
+        cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
       working-directory: tmp/risc0
       shell: bash
     - name: install r0vm from git

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -51,6 +51,10 @@ runs:
         path: 'tmp/risc0'
         ref: ${{ inputs.ref }}
         lfs: true
+    - name: install Rust toolchain
+      if: inputs.ref != ''
+      uses: risc0/risc0/.github/actions/rustup@main
+      working-directory: tmp/risc0
     - name: install cargo-risczero from git
       if: inputs.ref != ''
       run: cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
@@ -70,13 +74,11 @@ runs:
       working-directory: tmp/risc0
 
     # Only run this step if using version (installing from crates.io)
-    - name: install cargo-risczero from crates.io
+    - name: Install rzup
       if: inputs.version != ''
-      run: cargo install --locked cargo-risczero --version "${{ inputs.version }}" --no-default-features --features "${{ inputs.features }}"
-      shell: bash
-    - name: install rzup from git
-      if: inputs.version != ''
-      run: cargo install --git https://github.com/risc0/risc0.git rzup
+      run: |
+        curl -L https://risczero.com/install | bash
+        echo "$HOME/.risc0/bin" >> $GITHUB_PATH
       shell: bash
     - name: install toolchains
       if: inputs.version != ''

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -51,12 +51,14 @@ runs:
         path: 'tmp/risc0'
         ref: ${{ inputs.ref }}
         lfs: true
+    - name: install active Rust toolchain
+      if: inputs.ref != ''
+      run: rustup toolchain install
+      working-directory: tmp/risc0
+      shell: bash
     - name: install cargo-risczero from git
       if: inputs.ref != ''
-      # Use cargo build first, which should detect and download the correct Rust toolchain
-      run: |
-        cargo build --release --locked -p cargo-risczero --no-default-features --features "${{ inputs.features }}"
-        cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
+      run: cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"
       working-directory: tmp/risc0
       shell: bash
     - name: install r0vm from git

--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-    types: ["opened", "edited", "reopened", "synchronize"]
+    types: [ "opened", "edited", "reopened", "synchronize" ]
 
 permissions:
   pull-requests: write
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   create-linear-issue-pr:
+    # Skip if the PR is not from a fork.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Find or create a Linear Issue

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,8 @@ jobs:
         run: ../.github/scripts/forge-test.sh
         working-directory: examples
       - name: cargo run -F verify all examples
+        # Run the verification only if the PR is not from a fork.
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: ../.github/scripts/run-verify.sh
         working-directory: examples
         env:


### PR DESCRIPTION
This PR skips the Linear workflow (requiring `secrets.LINEAR_API_KEY`) and the example verify step (requiring `secrets.ALCHEMY_RISC0_ETH_API_KEY`) in PRs from forks.