### PR TITLE
WEB3-364: fix: limit op-alloy version to maintain Rust 1.81 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ alloy-rpc-types = { version = "0.11" }
 alloy-sol-types = { version = "0.8.18" }
 
 # OP Steel
-op-alloy-network = { version = "0.10.0" }
+op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
+op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 
 # Alloy host dependencies
 alloy = { version = "0.11" }

--- a/crates/op-steel/Cargo.toml
+++ b/crates/op-steel/Cargo.toml
@@ -18,6 +18,7 @@ alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-sol-types = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }
+op-alloy-consensus = { workspace = true }
 op-alloy-network = { workspace = true }
 revm = { workspace = true, features = ["std", "optimism"] }
 risc0-steel = { workspace = true }

--- a/examples/op/l1-to-l2/methods/guest/Cargo.toml
+++ b/examples/op/l1-to-l2/methods/guest/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 l1-to-l2-core = { path = "../../core" }
-op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
-op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 risc0-steel = { path = "../../../../../crates/steel" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std", "unstable"] }
 

--- a/examples/op/l1-to-l2/methods/guest/Cargo.toml
+++ b/examples/op/l1-to-l2/methods/guest/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 l1-to-l2-core = { path = "../../core" }
+op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
+op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 risc0-steel = { path = "../../../../../crates/steel" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std", "unstable"] }
 

--- a/examples/op/l2-to-l1/methods/guest/Cargo.toml
+++ b/examples/op/l2-to-l1/methods/guest/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 l2-to-l1-core = { path = "../../core" }
-op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
-op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 risc0-op-steel = { path = "../../../../../crates/op-steel" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std", "unstable"] }
 

--- a/examples/op/l2-to-l1/methods/guest/Cargo.toml
+++ b/examples/op/l2-to-l1/methods/guest/Cargo.toml
@@ -6,11 +6,9 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-alloy-network = { version = "=0.3.5" }
 l2-to-l1-core = { path = "../../core" }
-op-alloy-consensus = { version = "=0.2.11" }
-op-alloy-network = { version = "=0.2.11" }
-op-alloy-rpc-types = { version = "=0.2.11" }
+op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
+op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 risc0-op-steel = { path = "../../../../../crates/op-steel" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std", "unstable"] }
 

--- a/examples/op/l2/methods/guest/Cargo.toml
+++ b/examples/op/l2/methods/guest/Cargo.toml
@@ -6,11 +6,9 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-alloy-network = { version = "=0.3.5" }
 l2-core = { path = "../../core" }
-op-alloy-consensus = { version = "=0.2.11" }
-op-alloy-network = { version = "=0.2.11" }
-op-alloy-rpc-types = { version = "=0.2.11" }
+op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
+op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 risc0-op-steel = { path = "../../../../../crates/op-steel" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std", "unstable"] }
 

--- a/examples/op/l2/methods/guest/Cargo.toml
+++ b/examples/op/l2/methods/guest/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 l2-core = { path = "../../core" }
-op-alloy-consensus = { version = ">=0.10.0, <0.10.7" }
-op-alloy-network = { version = ">=0.10.0, <0.10.7" }
 risc0-op-steel = { path = "../../../../../crates/op-steel" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main", default-features = false, features = ["std", "unstable"] }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83"
+channel = "1.81"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = []
 profile = "minimal"


### PR DESCRIPTION
Starting with op-alloy 0.10.7 rust 1.81 is required which is not yet supported in the guest.