### PR TITLE
WEB3-367: Install r0vm

### DIFF
--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -75,13 +75,11 @@ runs:
       working-directory: tmp/risc0
 
     # Only run this step if using version (installing from crates.io)
-    - name: install cargo-risczero from crates.io
+    - name: install rzup
       if: inputs.version != ''
-      run: cargo install --locked cargo-risczero --version "${{ inputs.version }}" --no-default-features --features "${{ inputs.features }}"
-      shell: bash
-    - name: install rzup from git
-      if: inputs.version != ''
-      run: cargo install --git https://github.com/risc0/risc0.git rzup
+      run: |
+        curl -L https://risczero.com/install | bash
+        echo "$HOME/.risc0/bin" >> $GITHUB_PATH
       shell: bash
     - name: install r0vm
       if: inputs.version != ''

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -51,6 +51,11 @@ runs:
         path: 'tmp/risc0'
         ref: ${{ inputs.ref }}
         lfs: true
+    - name: install active Rust toolchain
+      if: inputs.ref != ''
+      run: rustup toolchain install
+      working-directory: tmp/risc0
+      shell: bash
     - name: install cargo-risczero from git
       if: inputs.ref != ''
       run: cargo install --locked --path risc0/cargo-risczero --no-default-features --features "${{ inputs.features }}"

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -78,6 +78,7 @@ runs:
     - name: install cargo-risczero from crates.io
       if: inputs.version != ''
       run: cargo install --locked cargo-risczero --version "${{ inputs.version }}" --no-default-features --features "${{ inputs.features }}"
+      shell: bash
     - name: install rzup
       if: inputs.version != ''
       run: |

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -78,6 +78,10 @@ runs:
       if: inputs.version != ''
       run: cargo install --git https://github.com/risc0/risc0.git rzup
       shell: bash
+    - name: install r0vm
+      if: inputs.version != ''
+      run: rzup install --verbose r0vm ${{ inputs.version }}
+      shell: bash
     - name: install toolchains
       if: inputs.version != ''
       run: |

--- a/.github/actions/cargo-risczero-install/action.yaml
+++ b/.github/actions/cargo-risczero-install/action.yaml
@@ -75,6 +75,9 @@ runs:
       working-directory: tmp/risc0
 
     # Only run this step if using version (installing from crates.io)
+    - name: install cargo-risczero from crates.io
+      if: inputs.version != ''
+      run: cargo install --locked cargo-risczero --version "${{ inputs.version }}" --no-default-features --features "${{ inputs.features }}"
     - name: install rzup
       if: inputs.version != ''
       run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81"
+channel = "1.83"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = []
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83"
+channel = "1.81"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = []
 profile = "minimal"


### PR DESCRIPTION
In the cargo-risczero-install action, specifically the path using the version (rather than the ref) the r0vm installation was missing