### PR TITLE
Fix grep Command Syntax for Consistency and Accuracy

### DIFF
--- a/.github/scripts/cargo-check.sh
+++ b/.github/scripts/cargo-check.sh
@@ -9,4 +9,4 @@ fmt_sort(){
   done
 }
 
-grep -rl --include "Cargo.toml" '\[workspace\]' | sort -u | fmt_sort
+grep -rl --include="Cargo.toml" '\[workspace\]' . | sort -u | fmt_sort


### PR DESCRIPTION
This PR improves the grep command syntax in the script to ensure correct execution across different environments.

Changes Made:
Added . after grep -rl → Ensures grep searches from the current directory, preventing missing results in subdirectories.
Updated --include "Cargo.toml" → --include="Cargo.toml" → Standardizes flag syntax for better readability and consistency.

These changes make the script more robust and consistent, preventing potential issues when running from different locations.