### PR TITLE
refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/crates/ffi/src/main.rs
+++ b/crates/ffi/src/main.rs
@@ -27,7 +27,7 @@ use risc0_forge_ffi::JournalSeal;
 use risc0_zkvm::{default_prover, ExecutorEnv, ProverOpts, VerifierContext};
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 enum Command {
     /// Prove the RISC-V ELF binary.
     Prove {

--- a/examples/erc20-counter/apps/src/bin/publisher.rs
+++ b/examples/erc20-counter/apps/src/bin/publisher.rs
@@ -62,40 +62,40 @@ sol!(
 #[derive(Parser)]
 struct Args {
     /// Ethereum private key
-    #[clap(long, env)]
+    #[arg(long, env = "ETH_WALLET_PRIVATE_KEY")]
     eth_wallet_private_key: PrivateKeySigner,
 
     /// Ethereum RPC endpoint URL
-    #[clap(long, env)]
+    #[arg(long, env = "ETH_RPC_URL")]
     eth_rpc_url: Url,
 
     /// Beacon API endpoint URL
     ///
     /// Steel uses a beacon block commitment instead of the execution block.
     /// This allows proofs to be validated using the EIP-4788 beacon roots contract.
-    #[clap(long, env)]
     #[cfg(any(feature = "beacon", feature = "history"))]
+    #[arg(long, env = "BEACON_API_URL")]
     beacon_api_url: Url,
 
     /// Ethereum block to use as the state for the contract call
-    #[clap(long, env, default_value_t = BlockNumberOrTag::Parent)]
+    #[arg(long, env = "EXECUTION_BLOCK", default_value_t = BlockNumberOrTag::Parent)]
     execution_block: BlockNumberOrTag,
 
     /// Ethereum block to use for the beacon block commitment.
-    #[clap(long, env)]
     #[cfg(feature = "history")]
+    #[arg(long, env = "COMMITMENT_BLOCK")]
     commitment_block: BlockNumberOrTag,
 
     /// Address of the Counter verifier contract
-    #[clap(long)]
+    #[arg(long)]
     counter_address: Address,
 
     /// Address of the ERC20 token contract
-    #[clap(long)]
+    #[arg(long)]
     token_contract: Address,
 
     /// Address to query the token balance of
-    #[clap(long)]
+    #[arg(long)]
     account: Address,
 }
 

--- a/examples/governance/apps/src/bin/publisher.rs
+++ b/examples/governance/apps/src/bin/publisher.rs
@@ -46,26 +46,26 @@ sol! {
 
 /// Arguments of the publisher CLI.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Args {
     /// Ethereum Wallet Private Key
-    #[clap(long, env)]
+    #[arg(long, env)]
     eth_wallet_private_key: PrivateKeySigner,
 
     /// Node RPC URL
-    #[clap(long)]
+    #[arg(long)]
     rpc_url: Url,
 
     /// Application's contract address on Ethereum
-    #[clap(long)]
+    #[arg(long)]
     contract: Address,
 
     /// The proposal ID (32 bytes, hex-encoded)
-    #[clap(long)]
+    #[arg(long)]
     proposal_id: Bytes,
 
     /// The votes data (hex-encoded, multiple of 100 bytes)
-    #[clap(long)]
+    #[arg(long)]
     votes_data: Bytes,
 }
 

--- a/examples/op/l1-to-l2/src/main.rs
+++ b/examples/op/l1-to-l2/src/main.rs
@@ -33,11 +33,11 @@ struct Args {
     l1_rpc_url: Url,
 
     /// URL of the L2 OP RPC endpoint
-    #[arg(long, env)]
+    #[arg(long, env = "L2_RPC_URL")]
     l2_rpc_url: Url,
 
     /// Beacon API endpoint URL
-    #[clap(long, env)]
+    #[arg(long, env = "BEACON_API_URL")]
     beacon_api_url: Url,
 }
 

--- a/examples/token-stats/host/src/main.rs
+++ b/examples/token-stats/host/src/main.rs
@@ -30,11 +30,11 @@ use url::Url;
 #[command(about, long_about = None)]
 struct Args {
     /// URL of the RPC endpoint
-    #[arg(long, env)]
+    #[arg(long, env = "RPC_URL")]
     rpc_url: Url,
 
     /// Beacon API endpoint URL
-    #[clap(long, env)]
+    #[arg(long, env = "BEACON_API_URL")]
     beacon_api_url: Url,
 }
 


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #480 