### PR TITLE
Fix typo in RiscZeroMockVerifier comments and update copyright year

### DIFF
--- a/contracts/src/test/RiscZeroMockVerifier.sol
+++ b/contracts/src/test/RiscZeroMockVerifier.sol
@@ -39,11 +39,11 @@ contract RiscZeroMockVerifier is IRiscZeroVerifier {
     using OutputLib for Output;
 
     /// @notice A short key attached to the seal to select the correct verifier implementation.
-    /// @dev A selector is not intended to be collision resistant, in that it is possible to find
-    ///      two preimages that result in the same selector. This is acceptable since its purpose
-    ///      to a route a request among a set of trusted verifiers, and to make errors of sending a
-    ///      receipt to a mismatching verifiers easier to debug. It is analogous to the ABI
-    ///      function selectors.
+    /// @dev A selector is not intended to be collision resistant in the sense that it is possible
+    ///      to find two preimages that result in the same selector. This is acceptable since its
+    ///      purpose is to route a request among a set of trusted verifiers, and to make errors of
+    ///      sending a receipt to a mismatching verifier easier to debug. It is analogous to the
+    ///      ABI function selectors.
     bytes4 public immutable SELECTOR;
 
     constructor(bytes4 selector) {

--- a/contracts/src/test/RiscZeroMockVerifier.sol
+++ b/contracts/src/test/RiscZeroMockVerifier.sol
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ contract RiscZeroMockVerifier is IRiscZeroVerifier {
 
     /// @notice A short key attached to the seal to select the correct verifier implementation.
     /// @dev A selector is not intended to be collision resistant, in that it is possible to find
-    ///      two preimages that result in the same selector. This is acceptable since it's purpose
+    ///      two preimages that result in the same selector. This is acceptable since its purpose
     ///      to a route a request among a set of trusted verifiers, and to make errors of sending a
     ///      receipt to a mismatching verifiers easier to debug. It is analogous to the ABI
     ///      function selectors.
@@ -62,7 +62,7 @@ contract RiscZeroMockVerifier is IRiscZeroVerifier {
 
     /// @notice internal implementation of verifyIntegrity, factored to avoid copying calldata bytes to memory.
     function _verifyIntegrity(bytes calldata seal, bytes32 claimDigest) internal view {
-        // Check that the seal has a matching selector. Mismatch generally  indicates that the
+        // Check that the seal has a matching selector. Mismatch generally indicates that the
         // prover and this verifier are using different parameters, and so the verification
         // will not succeed.
         if (SELECTOR != bytes4(seal[:4])) {

--- a/examples/governance/contracts/src/RiscZeroGovernorCounting.sol
+++ b/examples/governance/contracts/src/RiscZeroGovernorCounting.sol
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ abstract contract RiscZeroGovernorCounting is Governor {
 
         (bytes32 r, bytes32 s, uint8 v) = abi.decode(signature, (bytes32, bytes32, uint8));
 
-        // Hash into the ballot bx the 68-byte encoded ballot with signature.
+        // Hash into the ballot box the 68-byte encoded ballot with signature.
         // NOTE: Fields are aligned with 4 and 32 bytes boundaries.
         bytes memory encoded = abi.encodePacked(uint16(1), support, v, r, s, sigDigest);
 
@@ -131,7 +131,7 @@ abstract contract RiscZeroGovernorCounting is Governor {
     function _commitVote(uint256 proposalId, uint8 support, address account) internal {
         ProposalVote storage proposalVote = _proposalVotes[proposalId];
 
-        // Hash into the ballot bx the 24-byte encoded ballot without a signature.
+        // Hash into the ballot box the 24-byte encoded ballot without a signature.
         bytes memory encoded = abi.encodePacked(uint16(0), support, uint8(0), account);
 
         emit CommittedBallot(proposalId, encoded);


### PR DESCRIPTION
This PR includes the following changes:
- Fixes a typo in RiscZeroMockVerifier.sol by changing "it's" to "its" in the comments
- Updates the copyright year from 2024 to 2025
- Minor formatting improvements in comments

These changes help maintain code quality and ensure proper documentation.