### PR TITLE
WEB3-380: Fix decode_seal

### DIFF
--- a/contracts/src/groth16.rs
+++ b/contracts/src/groth16.rs
@@ -168,4 +168,17 @@ mod tests {
         .unwrap();
         receipt.verify(image_id).unwrap();
     }
+
+    #[test]
+    #[cfg(feature = "unstable")]
+    fn test_decode_fake_seal() {
+        use crate::receipt::decode_seal;
+        use risc0_zkvm::ReceiptClaim;
+
+        let fake_claim = ReceiptClaim::ok(Digest::default(), vec![]).digest();
+        let mut seal = vec![];
+        seal.extend_from_slice(&[0u8; 4]);
+        seal.extend_from_slice(fake_claim.as_bytes());
+        decode_seal(seal.into(), fake_claim, vec![]).unwrap();
+    }
 }

--- a/contracts/src/receipt.rs
+++ b/contracts/src/receipt.rs
@@ -101,7 +101,6 @@ pub fn decode_seal_with_claim(
     let selector = [seal[0], seal[1], seal[2], seal[3]];
     let selector = Selector::from_bytes(selector)
         .ok_or_else(|| DecodingError::UnsupportedSelector(selector))?;
-    let verifier_parameters = selector.verifier_parameters_digest()?;
     match selector.get_type() {
         SelectorType::FakeReceipt => {
             let receipt = risc0_zkvm::Receipt::new(
@@ -111,11 +110,13 @@ pub fn decode_seal_with_claim(
             Ok(Receipt::Base(Box::new(receipt)))
         }
         SelectorType::Groth16 => {
+            let verifier_parameters = selector.verifier_parameters_digest()?;
             let receipt =
                 decode_groth16_seal(seal, claim, journal.into(), Some(verifier_parameters))?;
             Ok(Receipt::Base(Box::new(receipt)))
         }
         SelectorType::SetVerifier => {
+            let verifier_parameters = selector.verifier_parameters_digest()?;
             let receipt = decode_set_inclusion_seal(&seal, claim, verifier_parameters)?;
             Ok(Receipt::SetInclusion(Box::new(receipt)))
         }


### PR DESCRIPTION
Fix a bug related to `decode_seal`, by not requiring verifier parameters when decoding a FakeReceipt