### PR TITLE
WEB3-380: Fix decode_seal (#494)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alloy",
  "alloy-primitives 0.8.21",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-forge-ffi"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "crates/aggregation/guest", "crates/ffi/guests"]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -12,9 +12,9 @@ repository = "https://github.com/risc0/risc0-ethereum/"
 [workspace.dependencies]
 # Intra-workspace dependencies
 risc0-aggregation = { version = "0.3.0", default-features = false, path = "crates/aggregation" }
-risc0-build-ethereum = { version = "1.4.0", default-features = false, path = "build" }
-risc0-ethereum-contracts = { version = "1.4.0", default-features = false, path = "contracts" }
-risc0-forge-ffi = { version = "1.4.0", default-features = false, path = "crates/ffi" }
+risc0-build-ethereum = { version = "1.4.1", default-features = false, path = "build" }
+risc0-ethereum-contracts = { version = "1.4.1", default-features = false, path = "contracts" }
+risc0-forge-ffi = { version = "1.4.1", default-features = false, path = "crates/ffi" }
 risc0-op-steel = { version = "0.2.0", default-features = false, path = "crates/op-steel" }
 risc0-steel = { version = "2.0.0-rc.2", default-features = false, path = "crates/steel" }
 

--- a/contracts/src/groth16.rs
+++ b/contracts/src/groth16.rs
@@ -169,4 +169,17 @@ mod tests {
         .unwrap();
         receipt.verify(image_id).unwrap();
     }
+
+    #[test]
+    #[cfg(feature = "unstable")]
+    fn test_decode_fake_seal() {
+        use crate::receipt::decode_seal;
+        use risc0_zkvm::ReceiptClaim;
+
+        let fake_claim = ReceiptClaim::ok(Digest::default(), vec![]).digest();
+        let mut seal = vec![];
+        seal.extend_from_slice(&[0u8; 4]);
+        seal.extend_from_slice(fake_claim.as_bytes());
+        decode_seal(seal.into(), fake_claim, vec![]).unwrap();
+    }
 }

--- a/contracts/src/receipt.rs
+++ b/contracts/src/receipt.rs
@@ -101,7 +101,6 @@ pub fn decode_seal_with_claim(
     let selector = [seal[0], seal[1], seal[2], seal[3]];
     let selector = Selector::from_bytes(selector)
         .ok_or_else(|| DecodingError::UnsupportedSelector(selector))?;
-    let verifier_parameters = selector.verifier_parameters_digest()?;
     match selector.get_type() {
         SelectorType::FakeReceipt => {
             let receipt = risc0_zkvm::Receipt::new(
@@ -111,11 +110,13 @@ pub fn decode_seal_with_claim(
             Ok(Receipt::Base(receipt))
         }
         SelectorType::Groth16 => {
+            let verifier_parameters = selector.verifier_parameters_digest()?;
             let receipt =
                 decode_groth16_seal(seal, claim, journal.into(), Some(verifier_parameters))?;
             Ok(Receipt::Base(receipt))
         }
         SelectorType::SetVerifier => {
+            let verifier_parameters = selector.verifier_parameters_digest()?;
             let receipt = decode_set_inclusion_seal(&seal, claim, verifier_parameters)?;
             Ok(Receipt::SetInclusion(receipt))
         }

--- a/examples/erc20-counter/Cargo.lock
+++ b/examples/erc20-counter/Cargo.lock
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alloy",
  "alloy-sol-types",

--- a/examples/governance/Cargo.lock
+++ b/examples/governance/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alloy",
  "alloy-sol-types",

--- a/examples/op/Cargo.lock
+++ b/examples/op/Cargo.lock
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alloy",
  "alloy-sol-types",


### PR DESCRIPTION
Fix a bug related to `decode_seal`, by not requiring verifier parameters when decoding a FakeReceipt
Bump version to v.1.4.1