### PR TITLE
WEB3-391: chore: Make OP `l1-to-l2` test more robust. (#512)

### DIFF
--- a/examples/op/l1-to-l2/src/main.rs
+++ b/examples/op/l1-to-l2/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
 
     let mut env = EthEvmEnv::builder()
         .rpc(args.l1_rpc_url)
-        .block_number_or_tag(BlockNumberOrTag::Safe)
+        .block_number_or_tag(BlockNumberOrTag::Finalized)
         .beacon_api(args.beacon_api_url)
         .build()
         .await?;


### PR DESCRIPTION
Using the latest safe block sometimes resulted in selecting a block that was too new; this has now been changed to the latest finalized block.