### PR TITLE
Add method for retrieving beacon block root from an EvmInput

### DIFF
--- a/crates/steel/src/block.rs
+++ b/crates/steel/src/block.rs
@@ -116,6 +116,10 @@ impl<H: EvmBlockHeader> BlockInput<H> {
 
         EvmEnv::new(db, header, commit)
     }
+
+    pub fn block_hash(&self) -> B256 {
+        self.header.seal_ref_slow().seal()
+    }
 }
 
 #[cfg(feature = "host")]

--- a/crates/steel/src/history/mod.rs
+++ b/crates/steel/src/history/mod.rs
@@ -34,7 +34,7 @@ pub type HistoryInput<H> = ComposeInput<H, HistoryCommit>;
 #[derive(Clone, Serialize, Deserialize)]
 pub struct HistoryCommit {
     /// Commit of the Steel EVM execution block hash to its beacon block hash.
-    evm_commit: BeaconCommit,
+    pub(crate) evm_commit: BeaconCommit,
     /// Iterative commits for verifying `evm_commit` as an ancestor of some valid Beacon block.
     state_commits: Vec<StateCommit>,
 }

--- a/crates/steel/src/lib.rs
+++ b/crates/steel/src/lib.rs
@@ -94,6 +94,26 @@ impl<H: EvmBlockHeader> EvmInput<H> {
             EvmInput::History(input) => input.into_env(),
         }
     }
+
+    /// Returns the beacon block root at the height/slot the input was created
+    ///
+    /// This can only be trusted after the input has been verified by calling `input.into_env()`
+    /// Note there is only an associated beacon block root for Beacon and History inputs.
+    pub fn beacon_block_root(&self) -> Option<B256> {
+        match self {
+            EvmInput::Block(_) => None,
+            EvmInput::Beacon(input) => {
+                let leaf = input.input.block_hash();
+                // safe to unwrap as long as commit is internally consistent
+                Some(input.commit.process_proof(leaf).unwrap())
+            }
+            EvmInput::History(input) => {
+                let leaf = input.input.block_hash();
+                // safe to unwrap as long as commit is internally consistent
+                Some(input.commit.evm_commit.process_proof(leaf).unwrap())
+            }
+        }
+    }
 }
 
 /// A trait linking the block header to a commitment.


### PR DESCRIPTION
For the Lido Oracle I have a requirement for a trusted beacon block root. This is used to verify beacon state inclusion proofs.

In my current implementation I actually independently implemented most of the history logic but now I am using Steel as well for execution layer proofs there is duplication. Also it would be much better to rely on a single implementation.

---

This PR:

- Adds a method to expose the beacon block root from the EvmInput which can act as a root of trust for the rest of the beacon SSZ proofs
- Adds tests using the beacon RPC
- Tests that the beacon root is invalidated if the proof data is tampered with
