### PR TITLE
WEB3-405: op-steel: Return correct commit for host env

### DIFF
--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -30,7 +30,7 @@ use risc0_steel::{
         db::{ProofDb, ProviderDb},
         BlockNumberOrTag, EvmEnvBuilder, HostCommit,
     },
-    ComposeInput, EvmEnv, EvmInput,
+    BlockHeaderCommit, Commitment, ComposeInput, EvmEnv, EvmInput,
 };
 use std::{
     marker::PhantomData,
@@ -95,6 +95,19 @@ where
         };
 
         Ok(OpEvmInput::Block(input))
+    }
+}
+
+impl<P2, C> HostOpEvmEnv<P2, C>
+where
+    P2: Provider<Optimism>,
+    C: Clone + BlockHeaderCommit<OpBlockHeader>,
+{
+    /// Returns the [Commitment] used to validate the environment.
+    pub fn commitment(&self) -> Commitment {
+        self.commit
+            .clone()
+            .commit(self.inner.header(), self.inner.commitment().configID)
     }
 }
 
@@ -322,13 +335,34 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::OutputRootProof;
     use alloy_primitives::address;
+    use risc0_steel::Account;
     use test_log::test;
 
     const L1_URL: &str = "https://ethereum-rpc.publicnode.com";
     const L2_URL: &str = "https://optimism-rpc.publicnode.com";
 
     const OP_PORTAL_ADDRESS: Address = address!("bEb5Fc579115071764c7423A4f12eDde41f106Ed");
+
+    #[test(tokio::test)]
+    async fn clone_op_block_builder() {
+        let builder = OpEvmEnv::builder().rpc(L2_URL.parse().unwrap());
+        // the builder should be cloneable
+        let _ = builder.clone();
+    }
+
+    #[test(tokio::test)]
+    #[ignore = "queries actual RPC nodes"]
+    async fn build_op_block_env() {
+        let builder = OpEvmEnv::builder().rpc(L2_URL.parse().unwrap());
+        let mut env = builder.build().await.unwrap();
+        let _ = Account::preflight(Address::ZERO, &mut env).info().await;
+
+        let host_commit = env.commitment();
+        let input = env.into_input().await.unwrap();
+        assert_eq!(input.into_env().into_commitment(), host_commit);
+    }
 
     #[test(tokio::test)]
     async fn clone_op_dispute_game_builder() {
@@ -342,9 +376,27 @@ mod tests {
 
     #[test(tokio::test)]
     #[ignore = "queries actual RPC nodes"]
-    async fn build_op_block_env() {
+    async fn build_op_dispute_game_env() {
         let builder = OpEvmEnv::builder().rpc(L2_URL.parse().unwrap());
-        // the builder should be cloneable
-        builder.clone().build().await.unwrap();
+        let env = builder.build().await.unwrap();
+        // mock an env with a dispute game commit, since building one requires an archive node
+        let block_hash = env.header().seal();
+        let mut env = HostOpEvmEnv {
+            inner: env.inner,
+            commit: DisputeGameCommit::new(
+                u64::MAX,
+                OutputRootProof {
+                    version: Default::default(),
+                    stateRoot: Default::default(),
+                    messagePasserStorageRoot: Default::default(),
+                    latestBlockhash: block_hash,
+                },
+            ),
+        };
+        let _ = Account::preflight(Address::ZERO, &mut env).info().await;
+
+        let host_commit = env.commitment();
+        let input = env.into_input().await.unwrap();
+        assert_eq!(input.into_env().into_commitment(), host_commit);
     }
 }

--- a/examples/op/l1-to-l2/src/main.rs
+++ b/examples/op/l1-to-l2/src/main.rs
@@ -17,8 +17,11 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use l1_to_l2_core::{CALL, CALLER, CONTRACT, IERC20};
 use l1_to_l2_methods::{L1_TO_L2_GUEST_ELF, L1_TO_L2_GUEST_ID};
-use risc0_op_steel::ethereum::{EthEvmEnv, ETH_MAINNET_CHAIN_SPEC};
-use risc0_op_steel::{host::BlockNumberOrTag, l1, Contract};
+use risc0_op_steel::{
+    ethereum::{EthEvmEnv, ETH_MAINNET_CHAIN_SPEC},
+    host::BlockNumberOrTag,
+    l1, Contract,
+};
 use risc0_zkvm::{default_prover, Digest, ExecutorEnv, ProverOpts, VerifierContext};
 use tokio::task;
 use tracing_subscriber::EnvFilter;

--- a/examples/op/l2-to-l1/src/main.rs
+++ b/examples/op/l2-to-l1/src/main.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy::primitives::{address, Address};
-use alloy::sol_types::SolCall;
+use alloy::{
+    primitives::{address, Address},
+    sol_types::SolCall,
+};
 use anyhow::{Context, Result};
 use clap::Parser;
 use l2_to_l1_core::{CALL, CALLER, CONTRACT, IERC20};
@@ -66,6 +68,7 @@ async fn main() -> Result<()> {
         CONTRACT,
         returns._0
     );
+    log::debug!("{:?}", env.commitment());
 
     let evm_input = env.into_input().await?;
 


### PR DESCRIPTION
The following now returns the correct dispute game commit:
```rust
let builder = OpEvmEnv::builder()
    .dispute_game_from_rpc(
        optimism_portal,
        Url::parse(l1_rpc_url).expect("Failed to parse RPC URL"),
    )
    .game_index(DisputeGameIndex::Finalized);

let op_env = builder
    .rpc(Url::parse(l2_rpc_url).expect("Failed to parse RPC URL"))
    .build()
    .await
    .expect("Failed to build OP-EVM environment");

let op_env_commitment = op_env.commitment();
```