### PR TITLE
WEB3-439: Update deployment.toml and selectors library with commits made to release-2.0

### DIFF
--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -118,6 +118,17 @@ set-builder-commit = "45a77235021f21ddc023d4655db0d6fd914de402"
 set-builder-image-id = "79fd473a707e7c064af3edabf63cad6c7ab9205766fd8d8160bdef97fdd15c74"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreiggmfeaohdbdwmhhsferpnrrjrd37h43hgwmu6yobwcd3qaavut6q"
 
+[[chains.ethereum-sepolia.verifiers]]
+name = "RiscZeroSetVerifier"
+version = "0.6.0"
+selector = "0x80479d24"
+verifier = "0xad2c6335191EA71Ffe2045A8d54b93A851ceca77"
+estop = "0x1A42D5b2fF29fbc2CB684836d222c561639b0bE4"
+# Build info for the set-builder guest
+set-builder-commit = "45a77235021f21ddc023d4655db0d6fd914de402"
+set-builder-image-id = "f584db3428af194f244e0ff74370918a649aab76"
+set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreifdozdfxhgdn6mcuq2mltbx7qaq5mie4iosq7kxj5rqmm4kg4qcfy"
+
 ###
 
 [chains.ethereum-holesky]

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -107,6 +107,17 @@ set-builder-commit = "8eadd4812fe44ba266a0565725c4fa654e4770e5"
 set-builder-image-id = "8888bf20b2be0ca935e166325578c336cc16355f9b63e7e5279c71a0a97f4df9"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreih46jdbjosixps7l3obrmfh4xlusnunohva6pfhqqdcyobaac4w4a"
 
+[[chains.ethereum-sepolia.verifiers]]
+name = "RiscZeroSetVerifier"
+version = "0.5.0"
+selector = "0xf2e6e6dc"
+verifier = "0x02f4D3E76876E5262f8D07Bc2258caE593e95013"
+estop = "0xb1216C4ECA3E3D69f9542Ae9b20b03c69693CC80"
+# Build info for the set-builder guest
+set-builder-commit = "45a77235021f21ddc023d4655db0d6fd914de402"
+set-builder-image-id = "79fd473a707e7c064af3edabf63cad6c7ab9205766fd8d8160bdef97fdd15c74"
+set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreiggmfeaohdbdwmhhsferpnrrjrd37h43hgwmu6yobwcd3qaavut6q"
+
 ###
 
 [chains.ethereum-holesky]

--- a/contracts/src/RiscZeroSetVerifier.sol
+++ b/contracts/src/RiscZeroSetVerifier.sol
@@ -47,7 +47,7 @@ contract RiscZeroSetVerifier is IRiscZeroSetVerifier {
     using ReceiptClaimLib for ReceiptClaim;
 
     /// Semantic version of the RISC Zero Set Verifier.
-    string public constant VERSION = "0.3.0-alpha.1";
+    string public constant VERSION = "0.6.0";
 
     /// Domain-separating tag value prepended to a digest before being hashed to form leaf node.
     ///

--- a/contracts/src/selector.rs
+++ b/contracts/src/selector.rs
@@ -46,6 +46,7 @@ pub enum Selector {
     SetVerifierV0_1 = 0xbfca9ccb,
     SetVerifierV0_2 = 0x16a15cc8,
     SetVerifierV0_4 = 0xf443ad7b,
+    SetVerifierV0_5 = 0xf2e6e6dc,
 }
 
 impl Display for Selector {
@@ -66,6 +67,7 @@ impl TryFrom<u32> for Selector {
             0xbfca9ccb => Ok(Selector::SetVerifierV0_1),
             0x16a15cc8 => Ok(Selector::SetVerifierV0_2),
             0xf443ad7b => Ok(Selector::SetVerifierV0_4),
+            0xf2e6e6dc => Ok(Selector::SetVerifierV0_5),
             _ => Err(SelectorError::UnsupportedSelector),
         }
     }
@@ -101,6 +103,10 @@ impl Selector {
                 "f443ad7bfe538ec90fa38498afd30b27b7d06336f20249b620a6d85ab3c615b6",
             )
             .unwrap()),
+            Selector::SetVerifierV0_5 => Ok(Digest::from_hex(
+                "f2e6e6dc660ed3ec9d8abb666cd481509c74990fc4d599f3f4a34b9df151f3fd",
+            )
+            .unwrap()),
         }
     }
 
@@ -110,9 +116,10 @@ impl Selector {
             Selector::Groth16V1_1 | Selector::Groth16V1_2 | Selector::Groth16V2_0 => {
                 SelectorType::Groth16
             }
-            Selector::SetVerifierV0_1 | Selector::SetVerifierV0_2 | Selector::SetVerifierV0_4 => {
-                SelectorType::SetVerifier
-            }
+            Selector::SetVerifierV0_1
+            | Selector::SetVerifierV0_2
+            | Selector::SetVerifierV0_4
+            | Selector::SetVerifierV0_5 => SelectorType::SetVerifier,
         }
     }
 
@@ -130,8 +137,8 @@ mod tests {
         Groth16ReceiptVerifierParameters,
     };
 
-    // SetBuilder image ID v0.4.0 (built using cargo risczero build v2.0.0)
-    const SET_BUILDER_ID: &str = "8888bf20b2be0ca935e166325578c336cc16355f9b63e7e5279c71a0a97f4df9";
+    // SetBuilder image ID v0.5.0 (built using cargo risczero build v2.0.1)
+    const SET_BUILDER_ID: &str = "79fd473a707e7c064af3edabf63cad6c7ab9205766fd8d8160bdef97fdd15c74";
 
     #[test]
     fn print_verifier_parameters() {

--- a/contracts/src/selector.rs
+++ b/contracts/src/selector.rs
@@ -47,6 +47,7 @@ pub enum Selector {
     SetVerifierV0_2 = 0x16a15cc8,
     SetVerifierV0_4 = 0xf443ad7b,
     SetVerifierV0_5 = 0xf2e6e6dc,
+    SetVerifierV0_6 = 0x80479d24,
 }
 
 impl Display for Selector {
@@ -68,6 +69,7 @@ impl TryFrom<u32> for Selector {
             0x16a15cc8 => Ok(Selector::SetVerifierV0_2),
             0xf443ad7b => Ok(Selector::SetVerifierV0_4),
             0xf2e6e6dc => Ok(Selector::SetVerifierV0_5),
+            0x80479d24 => Ok(Selector::SetVerifierV0_6),
             _ => Err(SelectorError::UnsupportedSelector),
         }
     }
@@ -107,6 +109,10 @@ impl Selector {
                 "f2e6e6dc660ed3ec9d8abb666cd481509c74990fc4d599f3f4a34b9df151f3fd",
             )
             .unwrap()),
+            Selector::SetVerifierV0_6 => Ok(Digest::from_hex(
+                "80479d24c20613acbaae52f5498cb60f661a26c0681ff2b750611dbaf9ecaa66",
+            )
+            .unwrap()),
         }
     }
 
@@ -119,7 +125,8 @@ impl Selector {
             Selector::SetVerifierV0_1
             | Selector::SetVerifierV0_2
             | Selector::SetVerifierV0_4
-            | Selector::SetVerifierV0_5 => SelectorType::SetVerifier,
+            | Selector::SetVerifierV0_5
+            | Selector::SetVerifierV0_6 => SelectorType::SetVerifier,
         }
     }
 
@@ -137,8 +144,8 @@ mod tests {
         Groth16ReceiptVerifierParameters,
     };
 
-    // SetBuilder image ID v0.5.0 (built using cargo risczero build v2.0.1)
-    const SET_BUILDER_ID: &str = "79fd473a707e7c064af3edabf63cad6c7ab9205766fd8d8160bdef97fdd15c74";
+    // SetBuilder image ID v0.6.0 (built using cargo risczero build v2.0.1)
+    const SET_BUILDER_ID: &str = "2fcedaa205bbfab6b804dec81e99cc9a22b20dea7a9701a1a7c55c7d26ef32f6";
 
     #[test]
     fn print_verifier_parameters() {


### PR DESCRIPTION
This is a cherry-pick of commit a452059 and 728ec4b. These were made to the `release-2.0` branch.

- **Deploy SetVerifierV0_5 (#533)**
- **Add SetVerifierV0_6**
