### PR TITLE
Update the Steel beacon block commit validation to always revert on invalid timestamps

### DIFF
--- a/contracts/src/steel/Steel.sol
+++ b/contracts/src/steel/Steel.sol
@@ -89,7 +89,7 @@ library Beacon {
     error BeaconRootContractCallFailed();
 
     /// @notice Find the root of the Beacon block corresponding to the parent of the execution block with the given timestamp.
-    /// @return root Returns the corresponding Beacon block root or null, if no such block exists.
+    /// @return root Returns the corresponding Beacon block root or reverts, if no such block exists.
     function parentBlockRoot(uint256 timestamp) internal view returns (bytes32 root) {
         (bool success, bytes memory result) = BEACON_ROOTS_ADDRESS.staticcall(abi.encode(timestamp));
         if (success) {

--- a/contracts/src/steel/Steel.sol
+++ b/contracts/src/steel/Steel.sol
@@ -84,12 +84,18 @@ library Beacon {
     /// @dev https://eips.ethereum.org/EIPS/eip-4788
     address internal constant BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
 
+    /// @notice call to the EIP-4788 beacon roots contract failed.
+    /// @dev This can occur if the given timestamp does not correspond to a beacon block root stored in the contract.
+    error BeaconRootContractCallFailed();
+
     /// @notice Find the root of the Beacon block corresponding to the parent of the execution block with the given timestamp.
     /// @return root Returns the corresponding Beacon block root or null, if no such block exists.
     function parentBlockRoot(uint256 timestamp) internal view returns (bytes32 root) {
         (bool success, bytes memory result) = BEACON_ROOTS_ADDRESS.staticcall(abi.encode(timestamp));
         if (success) {
             return abi.decode(result, (bytes32));
+        } else {
+            revert BeaconRootContractCallFailed();
         }
     }
 }


### PR DESCRIPTION
On `main`, the `Beacon.parentBlockRoot(uint256 timestamp)` function returns zero bytes if the timestamp given is invalid. This allows the `Steel.validateCommitment` to return true if given a commitment suchas `Commitment { id: Encoding.encodeVersionID(block.timestamp - 1, 1), bytes32(0), configID }` where the digest is zero and the timestamp is within the last ~24 hours but does not correspond to a valid block.

This violates the semantics of `validateCommitment` in that this does not commitment to a block that is in the current chain. Because the digest is zero, it does not correspond to any block and there exist no known openings. As a result, this commitment will never be produced by a correct zkVM guest using Steel. As a result, leveraging this bug to compromise the soundness of a program using Steel would require a separate bug or misuse of the Steel API.

As a fix for this issue, this PR checks whether the EIP-4788 contract call reverts, and reverts with `InvalidBlockTimestamp` if so. We choose this error message as this is the only case in which the EIP-4788 contract will revert when called from the `Beacon` contract. With this, this PR removes the explicit check that the timestamp is recent, as it is redundant.

As a drive-by change, this PR also drops the explicit check for the block number being too old when using execution block commitments. Instead, this checks the return value of the `blockhash` opcode, which will return zeroes if the block number is too old. This should not result in any change of behavior on Ethereum.
