### PR TITLE
WEB3-512: Disable alloy default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ alloy-op-evm = { version = "0.15" }
 op-alloy-network = { version = "0.18" }
 
 # Alloy host dependencies
-alloy = { version = "1.0" }
+alloy = { version = "1.0", default-features = false }
 alloy-trie = { version = "0.8" }
 
 # Beacon chain support

--- a/crates/op-steel/Cargo.toml
+++ b/crates/op-steel/Cargo.toml
@@ -13,7 +13,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-alloy = { workspace = true, optional = true, features = ["contract", "providers"] }
+alloy = { workspace = true, optional = true, features = ["std", "essentials"] }
 alloy-eips = { workspace = true }
 alloy-evm = { workspace = true }
 alloy-op-evm = { workspace = true }

--- a/crates/steel/Cargo.toml
+++ b/crates/steel/Cargo.toml
@@ -13,7 +13,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-alloy = { workspace = true, optional = true, features = ["full"] }
+alloy = { workspace = true, optional = true, features = ["std", "reqwest", "essentials"] }
 alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-evm = { workspace = true }
@@ -36,7 +36,7 @@ tokio = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]
-alloy = { workspace = true, features = ["contract", "node-bindings"] }
+alloy = { workspace = true, features = ["node-bindings"] }
 risc0-steel = { path = ".", features = ["host"] }
 serde_json = { workspace = true }
 test-log = { workspace = true }


### PR DESCRIPTION
With default features, alloy pulls in `native-tis` dependencies:

```console
cargo tree | grep native-tls
│   │   │   │   │   ├── native-tls v0.2.14
│   │   │   │   │   ├── tokio-native-tls v0.3.1
│   │   │   │   │   │   ├── native-tls v0.2.14 (*)
│   │   │   │   ├── native-tls v0.2.14 (*)
│   │   │   │   ├── tokio-native-tls v0.3.1 (*)
```