### PR TITLE
WEB3-516: fix: Steel documentation workflow

### DIFF
--- a/.github/workflows/steel-documentation.yml
+++ b/.github/workflows/steel-documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+*'  # matches v1.0, v1.1, v2.0, v2.1.0, etc.
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -27,17 +28,17 @@ jobs:
       # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
       - uses: actions/checkout@v4
-      
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
-      
+
       - uses: risc0/risc0/.github/actions/rustup@main
         with:
-          toolchain: nightly-2024-09-04
+          toolchain: nightly-2025-02-20
 
       - name: Build documentation
         run: |
-          if ! cargo +nightly-2024-09-04 doc -p risc0-steel --all-features --no-deps; then
+          if ! cargo +nightly-2025-02-20 doc -p risc0-steel --all-features --no-deps; then
             echo "Documentation build failed"
             exit 1
           fi


### PR DESCRIPTION
cargo doc requires edition2024, so the nightly needs to be updated to fix the failing documentation deploys.