### PR TITLE
WEB3-521: Mark risc0-zkvm 2.1 verifiers as stopped

### DIFF
--- a/contracts/deployment-test/Deployment.t.sol
+++ b/contracts/deployment-test/Deployment.t.sol
@@ -177,6 +177,7 @@ contract DeploymentTest is Test {
             require(
                 keccak256(address(verifierEstop).code) != keccak256(bytes("")), "verifier estop has no deployed code"
             );
+            require(verifierEstop.owner() == deployment.admin, "estop owner is not the admin address");
             if (verifierConfig.stopped) {
                 require(verifierEstop.paused(), "verifier estop is not stopped");
             } else {

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -48,6 +48,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0xDa8f3de6fBBdb261Ac771B813a578A7aBdA6B2b1"
+stopped = true
 
 [[chains.ethereum-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -162,6 +163,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.ethereum-sepolia.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -221,6 +223,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.ethereum-holesky.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -258,6 +261,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.ethereum-hoodi.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -317,6 +321,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0xDa8f3de6fBBdb261Ac771B813a578A7aBdA6B2b1"
+stopped = true
 
 [[chains.arbitrum-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -376,6 +381,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.arbitrum-sepolia.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -437,6 +443,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0xDa8f3de6fBBdb261Ac771B813a578A7aBdA6B2b1"
+stopped = true
 
 [[chains.avalanche-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -496,6 +503,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.avalanche-fuji.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -503,9 +511,6 @@ version = "2.2.0"
 selector = "0xbb001d44"
 verifier = "0xafB31f5b70623CDF4b20Ada3f7230916A5A79df9"
 estop = "0x7BE0Ca3734bB4B0aC66dD05714D25476bd658a9F"
-# As of July 7, we are having trouble sending the tx to add this verifier to the router.
-# TODO: Fix this.
-unroutable = true # remove when added to the router
 
 ###
 
@@ -569,6 +574,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0xDa8f3de6fBBdb261Ac771B813a578A7aBdA6B2b1"
+stopped = true
 
 [[chains.base-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -650,6 +656,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.base-sepolia.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -709,6 +716,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0xDa8f3de6fBBdb261Ac771B813a578A7aBdA6B2b1"
+stopped = true
 
 [[chains.optimism-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -770,6 +778,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0x54aCE3ED46529B4d4F3770C8Bad5dDC48717B9bF"
 estop = "0x9d6232CD50b5a2df431274f2633988f97bF3985f"
+stopped = true
 
 [[chains.optimism-sepolia.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -832,6 +841,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0xCb941DE7Fac82B1D768848ed267cc93B7AbE5AB6"
 estop = "0x8777853Dbe9694D7a146D8e17f7b6331BF75C64c"
+stopped = true
 
 [[chains.linea-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -894,6 +904,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0xCb941DE7Fac82B1D768848ed267cc93B7AbE5AB6"
 estop = "0x7D2da71AFC99198eFb25dF594A13aDa3C6D9Ada2"
+stopped = true
 
 [[chains.linea-sepolia.verifiers]]
 name = "RiscZeroGroth16Verifier"
@@ -977,6 +988,7 @@ version = "2.1.0"
 selector = "0xf536085a"
 verifier = "0xCb97eF56F2b3d8116b5B851bbe74ea31380fA7dD"
 estop = "0xC5cbE5B24231E3339CdD8D4F1F1F7e096D919790"
+stopped = true
 
 [[chains.polygon-zkevm-mainnet.verifiers]]
 name = "RiscZeroGroth16Verifier"

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -467,6 +467,9 @@ timelock-controller = "0xDC986a09728F76110FF666eE7b20d99086501d15"
 timelock-delay = 1
 router = "0x0b144E07A0826182B6b59788c34b32Bfa86Fb711"
 
+# NOTE: As of Aug 4, 2025, Fireblocks appears to have issues sending EIP-1559 transactions to Fuji
+# A workaround for this is to `forge script` in the `manage` script to disable use of EIP-1559.
+
 [[chains.avalanche-fuji.verifiers]]
 name = "RiscZeroGroth16Verifier"
 version = "1.1.0-rc.2"

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -171,6 +171,9 @@ Then, in the instructions below, pass the `--fireblocks` (`-f`) flag to the `man
     FOUNDRY_PROFILE=deployment-test forge test -vv --fork-url=${RPC_URL:?}
     ```
 
+6. If using Fireblocks, add the newly deployed timelock controller address to the like of allowed contract call destinations.
+   This allows future operations, e.g. adding a new verifier, that go through the timelock controller.
+
 ## Deploy a Groth16 verifier with emergency stop mechanism
 
 This is a two-step process, guarded by the `TimelockController`.
@@ -626,6 +629,10 @@ Activate the emergency stop:
 
 > ![WARNING]
 > Activating the emergency stop will make that verifier permanently inoperable.
+
+> ![NOTE]
+> In order to send a transaction to the estop contract in Fireblocks, the addresses need to be added to the allow-list.
+> If this has not already been done, do this as a pre-step.
 
 1. Set the verifier selector and estop address for the verifier:
 


### PR DESCRIPTION
Due to a constraints error in the division circuit in the zkVM, detailed in https://github.com/risc0/risc0/security/advisories/GHSA-f6rc-24x4-ppxp , the `risc0-zkvm 2.1` verifiers have had their estop activated.

This PR marks the verifiers as stopped in `deployment.toml`.

We also fix an issue with deployment to Avalance Fuji
