### PR TITLE
fix: correct script filename in usage message

### DIFF
--- a/contracts/generate_contract_address_table.py
+++ b/contracts/generate_contract_address_table.py
@@ -103,7 +103,7 @@ def main(toml_file, risc0_version, risc0_eth_version):
 
 if __name__ == "__main__":
     if len(sys.argv) != 4:
-        print("Usage: python generate_md.py <path_to_toml_file> <risc0-zkvm-version> <risc0-ethereum-version>")
+        print("Usage: python generate_contract_address_table.py <path_to_toml_file> <risc0-zkvm-version> <risc0-ethereum-version>")
         sys.exit(1)
 
     toml_file = sys.argv[1]


### PR DESCRIPTION
Update the usage message in generate_contract_address_table.py to reference the correct script filename instead of the incorrect "generate_md.py". This helps users run the script correctly when they see the usage error message.