### PR TITLE
WEB3-545: Mark set verifiers prior to 0.9 as stopped

### DIFF
--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -113,6 +113,7 @@ estop = "0xFB4D56bdEc378e6625e6448b037EFB4E5FCE085d"
 set-builder-commit = "abd97bca9533d70302b41f67020f7fd1e41d9cf7"
 set-builder-image-id = "7d75250e86556132c0e10c05b0f1d823ae72a5e277a596039576b6578cb25260"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/QmXVv8FErxhzxQiSEYDqwDA5bWLu7wEn7ZWcFvjAsfqJdW"
+stopped = true
 
 [[chains.ethereum-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"
@@ -124,6 +125,7 @@ estop = "0x9852f4B6b6554E4C723914a5500Fc57156EDE3F7"
 set-builder-commit = "8eadd4812fe44ba266a0565725c4fa654e4770e5"
 set-builder-image-id = "8888bf20b2be0ca935e166325578c336cc16355f9b63e7e5279c71a0a97f4df9"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreih46jdbjosixps7l3obrmfh4xlusnunohva6pfhqqdcyobaac4w4a"
+stopped = true
 
 [[chains.ethereum-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"
@@ -135,6 +137,7 @@ estop = "0xb1216C4ECA3E3D69f9542Ae9b20b03c69693CC80"
 set-builder-commit = "45a77235021f21ddc023d4655db0d6fd914de402"
 set-builder-image-id = "79fd473a707e7c064af3edabf63cad6c7ab9205766fd8d8160bdef97fdd15c74"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreiggmfeaohdbdwmhhsferpnrrjrd37h43hgwmu6yobwcd3qaavut6q"
+stopped = true
 
 [[chains.ethereum-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"
@@ -146,6 +149,7 @@ estop = "0x1A42D5b2fF29fbc2CB684836d222c561639b0bE4"
 set-builder-commit = "f584db3428af194f244e0ff74370918a649aab76"
 set-builder-image-id = "2fcedaa205bbfab6b804dec81e99cc9a22b20dea7a9701a1a7c55c7d26ef32f6"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreifdozdfxhgdn6mcuq2mltbx7qaq5mie4iosq7kxj5rqmm4kg4qcfy"
+stopped = true
 
 [[chains.ethereum-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"
@@ -157,6 +161,7 @@ estop = "0x46D0322760631084bFfC10b31962A47a527Ac042"
 set-builder-commit = "c09ee29b386d2b1486724509868d1115db36929f" # aggregation-v0.7.0
 set-builder-image-id = "a218e889a26852fd3d57a80983c76b53ff6d5fa4b469779511dd4d99329ae7aa"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreicn2oingurbfxdanqgzy6nwt2gexazlnh6jhj7h3k2ot47vw6fomq"
+stopped = true
 
 [[chains.ethereum-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"
@@ -665,6 +670,7 @@ estop = "0x226B6e6b37F92a1D620Eb41b833Cc92760268D4a"
 set-builder-commit = "f584db3428af194f244e0ff74370918a649aab76"
 set-builder-image-id = "2fcedaa205bbfab6b804dec81e99cc9a22b20dea7a9701a1a7c55c7d26ef32f6"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreifdozdfxhgdn6mcuq2mltbx7qaq5mie4iosq7kxj5rqmm4kg4qcfy"
+stopped = true
 
 [[chains.base-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"
@@ -676,6 +682,7 @@ estop = "0x5c5076c20b897F9b8dd2c5e68Bd62785BA3D319B"
 set-builder-commit = "c09ee29b386d2b1486724509868d1115db36929f" # aggregation-v0.7.0
 set-builder-image-id = "a218e889a26852fd3d57a80983c76b53ff6d5fa4b469779511dd4d99329ae7aa"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreicn2oingurbfxdanqgzy6nwt2gexazlnh6jhj7h3k2ot47vw6fomq"
+stopped = true
 
 [[chains.base-sepolia.verifiers]]
 name = "RiscZeroSetVerifier"

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -583,6 +583,7 @@ estop = "0xc0F0a64960187b83DcAA0e4bC2Ec05bfCbde9Fd7"
 set-builder-commit = "c09ee29b386d2b1486724509868d1115db36929f" # aggregation-v0.7.0
 set-builder-image-id = "a218e889a26852fd3d57a80983c76b53ff6d5fa4b469779511dd4d99329ae7aa"
 set-builder-elf-url = "https://gateway.pinata.cloud/ipfs/bafkreicn2oingurbfxdanqgzy6nwt2gexazlnh6jhj7h3k2ot47vw6fomq"
+stopped = true
 
 [[chains.base-mainnet.verifiers]]
 name = "RiscZeroSetVerifier"

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -638,27 +638,18 @@ Activate the emergency stop:
 > In order to send a transaction to the estop contract in Fireblocks, the addresses need to be added to the allow-list.
 > If this has not already been done, do this as a pre-step.
 
-1. Set the verifier selector and estop address for the verifier:
-
-    > TIP: One place to find this information is in `./contracts/test/RiscZeroGroth16Verifier.t.sol`
+1. Dry run the transaction
 
     ```sh
-    export VERIFIER_SELECTOR="0x..."
-    export VERIFIER_ESTOP=$(yq eval -e ".chains[\"${CHAIN_KEY:?}\"].verifiers[] | select(.selector == \"${VERIFIER_SELECTOR:?}\") | .estop" contracts/deployment.toml | tee /dev/stderr)
-    ```
-
-2. Dry run the transaction
-
-    ```sh
-    VERIFIER_ESTOP=${VERIFIER_ESTOP:?} \
+    VERIFIER_SELCTOR="0x..." \
     bash contracts/script/manage ActivateEstop
     ```
 
-3. Run the command again with `--broadcast`
+2. Run the command again with `--broadcast`
 
     This will send one transaction from the admin address.
 
-4. Test the activation:
+3. Test the activation:
 
     ```sh
     cast call --rpc-url ${RPC_URL:?} \

--- a/contracts/src/selector.rs
+++ b/contracts/src/selector.rs
@@ -42,16 +42,24 @@ pub enum Selector {
     FakeReceipt = 0xFFFFFFFF,
     Groth16V1_1 = 0x50bd1769,
     Groth16V1_2 = 0xc101b42b,
+    #[deprecated]
     Groth16V2_0 = 0x9f39696c,
+    #[deprecated]
     Groth16V2_1 = 0xf536085a,
     Groth16V2_2 = 0xbb001d44,
     Groth16V3_0 = 0x73c457ba,
     Groth16V5_0 = 0x7f3d0102,
+    #[deprecated]
     SetVerifierV0_1 = 0xbfca9ccb,
+    #[deprecated]
     SetVerifierV0_2 = 0x16a15cc8,
+    #[deprecated]
     SetVerifierV0_4 = 0xf443ad7b,
+    #[deprecated]
     SetVerifierV0_5 = 0xf2e6e6dc,
+    #[deprecated]
     SetVerifierV0_6 = 0x80479d24,
+    #[deprecated]
     SetVerifierV0_7 = 0x0f63ffd5,
     SetVerifierV0_9 = 0x242f9d5b,
 }
@@ -65,6 +73,7 @@ impl Display for Selector {
 impl TryFrom<u32> for Selector {
     type Error = SelectorError;
 
+    #[expect(deprecated)]
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             0xFFFFFFFF => Ok(Selector::FakeReceipt),
@@ -89,6 +98,7 @@ impl TryFrom<u32> for Selector {
 
 impl Selector {
     pub fn verifier_parameters_digest(self) -> Result<Digest, SelectorError> {
+        #[expect(deprecated)]
         match self {
             Selector::FakeReceipt => {
                 Err(SelectorError::NoVerifierParameters(Selector::FakeReceipt))
@@ -153,6 +163,7 @@ impl Selector {
     }
 
     pub fn get_type(self) -> SelectorType {
+        #[expect(deprecated)]
         match self {
             Selector::FakeReceipt => SelectorType::FakeReceipt,
             Selector::Groth16V1_1


### PR DESCRIPTION
Due to https://github.com/risc0/risc0/security/advisories/GHSA-jqq4-c7wq-36h7 , set verifier deployments prior to 0.9 are vulnerable. All deployments have now been disabled, and this PR updates the deployment.toml to reflect this.
