### PR TITLE
Fix forge fmt test to match new behavior in 1.5

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -229,7 +229,6 @@ contract Counter {
 count-=1;
     }
 }
-
 "#;
 
     #[test]


### PR DESCRIPTION
This change was applied to `main` in f8998f3ac7759e3e4b00149560147dec5480241a