### PR TITLE
Reject non-canonical trie hex-prefix paths

### DIFF
--- a/crates/trie/src/mpt/mod.rs
+++ b/crates/trie/src/mpt/mod.rs
@@ -559,6 +559,22 @@ mod tests {
     }
 
     #[test]
+    fn rejects_noncanonical_even_hex_prefix_paths() {
+        let canonical_leaf = [0xc2, 0x20, 0x76];
+        let noncanonical_leaf = [0xc2, 0x2f, 0x76];
+        assert!(CachedTrie::from_rlp([canonical_leaf]).is_ok());
+        assert!(CachedTrie::from_rlp([noncanonical_leaf]).is_err());
+
+        let extension = |prefix: u8| {
+            let mut rlp = vec![0xe4, 0x82, prefix, 0xab, 0xa0];
+            rlp.extend([0; 32]);
+            rlp
+        };
+        assert!(CachedTrie::from_rlp([extension(0x00)]).is_ok());
+        assert!(CachedTrie::from_rlp([extension(0x0f)]).is_err());
+    }
+
+    #[test]
     #[should_panic]
     fn get_digest() {
         let trie = Trie(Node::Digest(B256::ZERO));

--- a/crates/trie/src/mpt/rlp.rs
+++ b/crates/trie/src/mpt/rlp.rs
@@ -422,7 +422,14 @@ fn decode_path(buf: &mut &[u8]) -> alloy_rlp::Result<(Nibbles, bool)> {
         0b0011 => (true, true),
         _ => return Err(alloy_rlp::Error::Custom("node is not an extension or leaf")),
     };
-    let prefix = if odd_nibbles { &path[1..] } else { &path[2..] };
+    let prefix = if odd_nibbles {
+        &path[1..]
+    } else {
+        if path[1] != 0 {
+            return Err(alloy_rlp::Error::Custom("non-canonical hex-prefix path"));
+        }
+        &path[2..]
+    };
     Ok((Nibbles::from_nibbles_unchecked(prefix), is_leaf))
 }
 


### PR DESCRIPTION
## Summary

- reject even MPT hex-prefix encodings with a non-zero filler nibble
- add regression coverage for canonical and non-canonical leaf and extension paths

Fixes #734

## Testing

- `cargo fmt --all --check`
- `cargo test -p risc0-ethereum-trie rejects_noncanonical_even_hex_prefix_paths`
- `cargo test -p risc0-ethereum-trie`
