### PR TITLE
Handle missing Forge FFI guest ELF

### DIFF
--- a/crates/ffi/src/main.rs
+++ b/crates/ffi/src/main.rs
@@ -63,7 +63,8 @@ pub fn main() -> Result<()> {
 
 /// Prints on stdio the Ethereum ABI and hex-encoded proof.
 fn prove_ffi(elf_path: String, input: Vec<u8>) -> Result<Vec<u8>> {
-    let elf = std::fs::read(elf_path).expect("failed to read guest ELF");
+    let elf = std::fs::read(&elf_path)
+        .with_context(|| format!("failed to read guest ELF at {elf_path}"))?;
     let (journal, seal) = prove(&elf, &input)?;
     let calldata = JournalSeal {
         journal: journal.into(),

--- a/crates/ffi/tests/basic.rs
+++ b/crates/ffi/tests/basic.rs
@@ -53,6 +53,25 @@ fn basic_usage() {
     assert_eq!(expect_seal, seal.to_vec());
 }
 
+#[test]
+fn missing_guest_binary_returns_error() {
+    let exe_path = env!("CARGO_BIN_EXE_risc0-forge-ffi");
+    let output = Command::new(exe_path)
+        .env_clear()
+        .arg("prove")
+        .arg("/tmp/risc0-forge-ffi-missing-guest")
+        .arg("0xdeadbeef")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to read guest ELF at /tmp/risc0-forge-ffi-missing-guest"),
+        "unexpected stderr: {stderr}",
+    );
+}
+
 // It's important that `risc0-forge-ffi` only send to stdout the output to be consumed by forge
 // with the FFI cheatcode. If any extra output is sent, ABI decoding will fail.
 #[test]


### PR DESCRIPTION
The Forge FFI helper used `expect` when reading the guest ELF, which panics on a missing or unreadable path.

This returns a contextual error through the existing `anyhow::Result` path instead and adds a regression test for a missing guest binary.